### PR TITLE
Plandomizer Page: Saving and Loading

### DIFF
--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -65,6 +65,7 @@ import { PlandoSpiritsAndChaptersComponent } from './pages/plando-page/plando-sp
 import { PlandoPartyComponent } from './pages/plando-page/plando-party/plando-party.component';
 import { PlandoBadgesComponent } from './pages/plando-page/plando-badges/plando-badges.component';
 import { PlandoItemsComponent } from './pages/plando-page/plando-items/plando-items.component';
+import { PlandoSaveLoadComponent } from './pages/plando-page/plando-save-load/plando-save-load.component';
 
 const dbConfig: DBConfig  = {
   name: 'db',
@@ -124,6 +125,7 @@ const toasterConfig: Partial<GlobalConfig> = {
     PlandoPartyComponent,
     PlandoBadgesComponent,
     PlandoItemsComponent,
+    PlandoSaveLoadComponent,
   ],
   imports: [
     BrowserModule,

--- a/app/src/app/pages/plando-page/plando-badges/plando-badges.component.html
+++ b/app/src/app/pages/plando-page/plando-badges/plando-badges.component.html
@@ -5,11 +5,11 @@
         <div *ngFor="let badge of BADGES" [formGroupName]="badge.id" class="badge-entry">
             <span>{{toDisplayString(badge.id) + ':'}}</span>
             <div>
-                <input formControlName="BP" type="number" min="0" [max]="MAX_BP" (input)="inputFilters.filterNumericInput($event, badgeMoveCostsFormGroup, badge.id + '.' + 'BP')" />
+                <input formControlName="BP" type="number" min="0" [max]="MAX_BP" (input)="inputFilters.filterNumericInput($event, badgeMoveCostsFormGroup, [badge.id, 'BP'])" />
                 <span>&nbsp;BP</span>
             </div>
             <span *ngIf="badge.hasFPCost">
-                <input formControlName="FP" type="number" min="0" [max]="MAX_FP" (input)="inputFilters.filterNumericInput($event, badgeMoveCostsFormGroup, badge.id + '.' + 'FP')" />
+                <input formControlName="FP" type="number" min="0" [max]="MAX_FP" (input)="inputFilters.filterNumericInput($event, badgeMoveCostsFormGroup, [badge.id, 'FP'])" />
                 <span>&nbsp;FP</span>
             </span>
         </div>

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.html
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.html
@@ -37,15 +37,15 @@
                                 <ng-container *ngIf="check.type !== CHECK_TYPES.SHOP">
                                     <label>{{toDisplayString(check.name)}}: </label>
                                     <input [formControlName]="check.name" [matAutocomplete]="auto"
-                                        (input)="updateAutoCompleteFilter($event)" (blur)="onNameInputBlur(loc.name + '.' + check.name)" (focus)="resetFilter($event)" />
+                                        (input)="updateAutoCompleteFilter($event)" (blur)="onNameInputBlur([loc.name, check.name])" (focus)="resetFilter($event)" />
                                 </ng-container>
                                 <ng-container *ngIf="check.type === CHECK_TYPES.SHOP" [formGroupName]="check.name">
                                     <label>{{toDisplayString(check.name)}}: </label>
                                     <input formControlName="item" [matAutocomplete]="auto"
-                                        (input)="updateAutoCompleteFilter($event)" (blur)="onNameInputBlur(loc.name + '.' + check.name + '.item')" (focus)="resetFilter($event)" />
+                                        (input)="updateAutoCompleteFilter($event)" (blur)="onNameInputBlur([loc.name, check.name, 'item'])" (focus)="resetFilter($event)" />
                                     <label>&nbsp;Price:</label>
                                     <input type="number" formControlName="price" min="0" max="999"
-                                        (input)="inputFilters.filterNumericInput($event, itemsFormGroup, loc.name + '.' + check.name + '.price')" />
+                                        (input)="inputFilters.filterNumericInput($event, itemsFormGroup, [loc.name, check.name, 'price'])" />
                                 </ng-container>
                             </div>
                         </ng-container>

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -1182,7 +1182,7 @@ export class PlandoItemsComponent {
     }
   }
 
-  public onNameInputBlur(formControlName: string) {
+  public onNameInputBlur(formControlName: string[]) {
     this.itemsFormGroup.get(formControlName).updateValueAndValidity();
   }
 

--- a/app/src/app/pages/plando-page/plando-page.component.html
+++ b/app/src/app/pages/plando-page/plando-page.component.html
@@ -37,11 +37,16 @@
             </mat-tab-group>
         </mat-card>
         <mat-card class="settings-card">
-            <div class="button-container">
-                <button [disabled]="formGroup.invalid || isValidating" class="submit" type="button" (click)="onSubmit()"
-                    [matTooltip]="formGroup.invalid ? 'Please fix the errors on the page to submit. Problems are highlighted in red.' : ''" matTooltipPosition="right">
-                    <span *ngIf="!isValidating">Download Plando File</span>
-                    <app-loading *ngIf="isValidating" [isLoading]="isValidating" [loadingText]="'Validating...'"></app-loading>
+            <div class="container space-between">
+                <div class="button-container">
+                    <button [disabled]="formGroup.invalid || isValidating" class="submit" type="button" (click)="onSubmit()"
+                        [matTooltip]="formGroup.invalid ? 'Please fix the errors on the page to submit. Problems are highlighted in red.' : ''" matTooltipPosition="right">
+                        <span *ngIf="!isValidating">Download Plando File</span>
+                        <app-loading *ngIf="isValidating" [isLoading]="isValidating" [loadingText]="'Validating...'"></app-loading>
+                    </button>
+                </div>
+                <button class="yellow-button" type="button" (click)="resetPlandoForm()">
+                    <span>Reset</span>
                 </button>
             </div>
         </mat-card>

--- a/app/src/app/pages/plando-page/plando-page.component.html
+++ b/app/src/app/pages/plando-page/plando-page.component.html
@@ -4,9 +4,6 @@
     </a>
 </div>
 <div class="main-page">
-    <mat-card class="settings-card">
-        <app-plando-save-load [plandoFormGroup]="formGroup"></app-plando-save-load>
-    </mat-card>
     <form [formGroup]="formGroup">
         <mat-card class="settings-card">
             <mat-tab-group disablePagination="true" animationDuration="0" scrollToCenter>
@@ -51,4 +48,7 @@
             </div>
         </mat-card>
     </form>
+    <mat-card class="settings-card">
+        <app-plando-save-load [plandoFormGroup]="formGroup"></app-plando-save-load>
+    </mat-card>
 </div>

--- a/app/src/app/pages/plando-page/plando-page.component.html
+++ b/app/src/app/pages/plando-page/plando-page.component.html
@@ -3,8 +3,11 @@
         <img src="../../../assets/images/plando/plandologo.png" class="logo">
     </a>
 </div>
-<form [formGroup]="formGroup">
-    <div class="main-page">
+<div class="main-page">
+    <mat-card class="settings-card">
+        <app-plando-save-load [plandoFormGroup]="formGroup"></app-plando-save-load>
+    </mat-card>
+    <form [formGroup]="formGroup">
         <mat-card class="settings-card">
             <mat-tab-group disablePagination="true" animationDuration="0" scrollToCenter>
                 <mat-tab>
@@ -42,5 +45,5 @@
                 </button>
             </div>
         </mat-card>
-    </div>
-</form>
+    </form>
+</div>

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -192,8 +192,9 @@
       border-color: $yellow-stat-border;
       min-width: 500px;
     }
-    button:disabled {
-      cursor: not-allowed;
-    }
+  }
+  button:disabled {
+    opacity: 35%;
+    cursor: not-allowed;
   }
 }

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -45,6 +45,9 @@
       flex: 1 1 100%;
       margin: 10px 0;
     }
+    .row.start {
+      justify-content: start;
+    }
     .end {
       justify-content: end;
     }

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -22,6 +22,18 @@
   }
 
   .panel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    flex: 0 1 20%;
+    min-width: 250px;
+    background-color: $blue-background-card;
+    margin: 10px;
+    border-radius: 15px;
+    padding: 0.5rem;
+    box-shadow: #919191 2px 2px 4px 0px;
+
     input[type="checkbox"] {
       visibility: hidden;
     }
@@ -42,17 +54,6 @@
     label {
       margin-right: 1rem;
     }
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
-    flex: 0 1 20%;
-    min-width: 250px;
-    background-color: $blue-background-card;
-    margin: 10px;
-    border-radius: 15px;
-    padding: 0.5rem;
-    box-shadow: #919191 2px 2px 4px 0px;
     app-tooltip-span {
       position: relative;
     }
@@ -156,7 +157,7 @@
                 background-color: $purple-misc-main !important;
                 border-color: $purple-misc-border !important;
               }
-              
+
               .mat-tab-label:has(> div > label.error) {
                 background-color: #650b0b !important;
               }

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -17,6 +17,9 @@
     flex-wrap: wrap;
     justify-content: center;
   }
+  .container.space-between {
+    justify-content: space-between;
+  }
 
   .panel {
     input[type="checkbox"] {

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from "@angular/forms";
 import { BADGE_LIST } from "./plando-badges/plando-badges.component";
 import { CheckType, LOCATIONS_LIST, PLANDO_ITEMS_LIST } from "./plando-items/plando-items.component";
@@ -15,7 +15,7 @@ const manualTrapRegex = new RegExp('^TRAP \\((' + PLANDO_ITEMS_LIST.slice(4).map
   templateUrl: './plando-page.component.html',
   styleUrls: ['./plando-page.component.scss']
 })
-export class PlandoPageComponent implements OnInit {
+export class PlandoPageComponent implements OnInit, OnDestroy {
   public formGroup: FormGroup
   public isValidating: boolean = false;
   public plandoName: FormControl = new FormControl('');
@@ -118,6 +118,14 @@ export class PlandoPageComponent implements OnInit {
       }
       (this.formGroup.get('items') as FormGroup).addControl(location.name, locationFormGroup);
     }
+    const savedFormObj = localStorage.getItem('autosavePlandoSettings');
+    if (savedFormObj) {
+      this.formGroup.setValue(JSON.parse(savedFormObj));
+    }
+  }
+
+  public ngOnDestroy(): void {
+    localStorage.setItem('autosavePlandoSettings', JSON.stringify(this.formGroup.getRawValue()));
   }
 
   private itemNameValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -85,13 +85,13 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
           })
         }),
         starpower: new FormGroup({
-          'Refresh': new FormControl<number>(null),
-          'Lullaby': new FormControl<number>(null),
-          'StarStorm': new FormControl<number>(null),
-          'ChillOut': new FormControl<number>(null),
-          'Smooch': new FormControl<number>(null),
-          'TimeOut': new FormControl<number>(null),
-          'UpAndAway': new FormControl<number>(null)
+          'Refresh': new FormControl<number>(-1),
+          'Lullaby': new FormControl<number>(-1),
+          'StarStorm': new FormControl<number>(-1),
+          'ChillOut': new FormControl<number>(-1),
+          'Smooch': new FormControl<number>(-1),
+          'TimeOut': new FormControl<number>(-1),
+          'UpAndAway': new FormControl<number>(-1)
         })
       }),
       items: new FormGroup({})

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -3,6 +3,7 @@ import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn,
 import { BADGE_LIST } from "./plando-badges/plando-badges.component";
 import { CheckType, LOCATIONS_LIST, PLANDO_ITEMS_LIST } from "./plando-items/plando-items.component";
 import { escapeRegexChars } from "src/app/utilities/stringFunctions";
+import { STAR_SPIRIT_POWER_NAMES } from "./plando-spirits-and-chapters/plando-spirits-and-chapters.component";
 
 export const MAX_FP_COST = 75;
 export const MAX_BP_COST = 10;
@@ -133,6 +134,16 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
       return null;
     }
     return { invalidPlandoItem: { value: control.value } };
+  }
+
+  public resetPlandoForm() {
+    if (confirm('This will reset all plando settings. Are you sure?')) {
+      this.formGroup.reset();
+      for (const power of STAR_SPIRIT_POWER_NAMES) {
+        this.formGroup.get('move_costs').get('starpower').get(power).setValue(-1);
+      }
+      this.formGroup.get('move_costs').get('starpower').updateValueAndValidity();
+    }
   }
 
   public onSubmit() {

--- a/app/src/app/pages/plando-page/plando-party/plando-party.component.html
+++ b/app/src/app/pages/plando-page/plando-party/plando-party.component.html
@@ -6,7 +6,7 @@
         <div *ngFor="let move of partner.moves;" [formGroupName]="partner.name" class="move-grid">
             <label [for]="move.id">{{toDisplayString(move) + ':'}}</label>
             <input [name]="move.id" type="number" [formControlName]="move" min="0" [max]="MAX_FP" data-prev-value=""
-                (input)="inputFilters.filterNumericInput($event, partnerMoveCostsFormGroup, partner.name + '.' + move)">
+                (input)="inputFilters.filterNumericInput($event, partnerMoveCostsFormGroup, [partner.name, move])">
             <span>&nbsp;FP</span>
         </div>
     </div>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -1,15 +1,38 @@
-<h3>Save & Load Plando Configs</h3>
+<h2>Save & Load Plando Configs</h2>
+<div class="container">
+    <div class="panel" [formGroup]="saveLoadFormGroup">
+        <div class="row start">
+            <p>All current changes will be auto-saved, and will auto-load when returning to this page. Use the controls below if you'd like to create and save multiple plandos.</p>
+        </div>
 
-<label>
-    <span>Plando Name:</span>
-    <input #plandoName />
-</label>
-<button type="button" (click)="savePlandoSettings(plandoName.value)" [disabled]="plandoName.value.trim() !== ''">Save</button>
+        <div class="row start">
+            <label for="plandoName">Plando Name:</label>
+            <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',')" />
+            <button class="yellow-button" type="button" (click)="savePlandoSettings(plandoName.value)"><span>Save</span></button>
+            <ng-container *ngIf="saveLoadStatus === 'saved'">
+                <span>✔️</span>
+                <span class="success">Plando Saved!</span>
+            </ng-container>
+        </div>
 
-<label>
-    <span>Load previous Plando:</span>
-    <select #loadDropDown>
-        <option *ngFor="let plandoName of getSavedPlandos()">{{plandoName}}</option>
-    </select>
-</label>
-<button type="button" (click)="loadPlandoSettings(loadDropDown.value)">Load</button>
+        <div class="row start" *ngIf="savedPlandoNames.size > 0">
+            <label for="savedPlandosSelect">Saved Plandos:</label>
+            <select name="savedPlandosSelect" #savedPlandosSelect formControlName="savedPlandoNameSelect">
+                <option></option>
+                <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
+            </select>
+            <div>
+                <button class="yellow-button" type="button" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
+                <button class="yellow-button" type="button" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
+                <ng-container *ngIf="saveLoadStatus === 'loaded'">
+                    <span>✔️</span>
+                    <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>
+                </ng-container>
+                <ng-container *ngIf="saveLoadStatus === 'deleted'">
+                    <span>✔️</span>
+                    <span class="success">Deleted Plando: {{this.lastPlandoName}}</span>
+                </ng-container>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -1,0 +1,15 @@
+<h3>Save & Load Plando Configs</h3>
+
+<label>
+    <span>Plando Name:</span>
+    <input #plandoName />
+</label>
+<button type="button" (click)="savePlandoSettings(plandoName.value)" [disabled]="plandoName.value.trim() !== ''">Save</button>
+
+<label>
+    <span>Load previous Plando:</span>
+    <select #loadDropDown>
+        <option *ngFor="let plandoName of getSavedPlandos()">{{plandoName}}</option>
+    </select>
+</label>
+<button type="button" (click)="loadPlandoSettings(loadDropDown.value)">Load</button>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -18,12 +18,11 @@
         <div class="row start" *ngIf="savedPlandoNames.size > 0">
             <label for="savedPlandosSelect">Saved Plandos:</label>
             <select name="savedPlandosSelect" #savedPlandosSelect formControlName="savedPlandoNameSelect">
-                <option></option>
                 <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
             </select>
             <div>
-                <button class="yellow-button" type="button" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
-                <button class="yellow-button" type="button" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
+                <button class="yellow-button" type="button" [disabled]="savedPlandosSelect.value === ''" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
+                <button class="yellow-button" type="button" [disabled]="savedPlandosSelect.value === ''" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
                 <ng-container *ngIf="saveLoadStatus === 'loaded'">
                     <span>✔️</span>
                     <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -8,7 +8,7 @@
         <div class="row start">
             <label for="plandoName">Plando Name:</label>
             <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',')" />
-            <button class="yellow-button" type="button" (click)="savePlandoSettings(plandoName.value)"><span>Save</span></button>
+            <button class="yellow-button" type="button" [disabled]="plandoName.value.trim() === ''" (click)="savePlandoSettings(plandoName.value)"><span>Save</span></button>
             <ng-container *ngIf="saveLoadStatus === 'saved'">
                 <span>✔️</span>
                 <span class="success">Plando Saved!</span>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
@@ -1,0 +1,11 @@
+:host {
+    .panel {
+        flex: 0 1 100%;
+    }
+    select {
+        min-width: 15rem;
+    }
+    button {
+        margin: 0.5rem;
+    }
+}

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.spec.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlandoSaveLoadComponent } from './plando-save-load.component';
+
+describe('PlandoSaveLoadComponent', () => {
+  let component: PlandoSaveLoadComponent;
+  let fixture: ComponentFixture<PlandoSaveLoadComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlandoSaveLoadComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlandoSaveLoadComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -31,8 +31,6 @@ export class PlandoSaveLoadComponent implements OnInit {
     localStorage.setItem(name, JSON.stringify(this.plandoFormGroup.getRawValue()))
     this.savedPlandoNames.add(name);
     localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
-    this.saveLoadFormGroup.get('plandoName').reset();
-    this.saveLoadFormGroup.get('plandoName').updateValueAndValidity();
     this.saveLoadStatus = 'saved';
     this.lastPlandoName = name;
     setTimeout(() => {

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -40,7 +40,7 @@ export class PlandoSaveLoadComponent {
       }
       const powercosts = plandoFormObj['move_costs']['starpower'];
       for (const power of STAR_SPIRIT_POWER_NAMES) {
-        if (!powercosts[power]) {
+        if (powercosts[power] === undefined || powercosts[power] === null) {
           powercosts[power] = -1;
         }
       }

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -1,0 +1,51 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from "@angular/forms";
+import { STAR_SPIRIT_POWER_NAMES } from "../plando-spirits-and-chapters/plando-spirits-and-chapters.component";
+
+@Component({
+  selector: 'app-plando-save-load',
+  templateUrl: './plando-save-load.component.html',
+  styleUrls: ['../plando-page.component.scss', './plando-save-load.component.scss']
+})
+export class PlandoSaveLoadComponent {
+  @Input() plandoFormGroup: FormGroup;
+  private savedPlandoNames: Set<string> = new Set(this.getSavedPlandos());
+  private readonly SAVED_PLANDO_NAMES_KEY = 'savedPlandoNames';
+
+  public getSavedPlandos(): Array<string> {
+    const savedNames = localStorage.getItem(this.SAVED_PLANDO_NAMES_KEY);
+    return savedNames ? savedNames.split(',') : [];
+  }
+
+  public savePlandoSettings(name: string) {
+    localStorage.setItem(name, JSON.stringify(this.plandoFormGroup.getRawValue()))
+    this.savedPlandoNames.add(name);
+    localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
+  };
+
+  public loadPlandoSettings(name: string) {
+    const plandoSettings = localStorage.getItem(name);
+    if (!plandoSettings) {
+      this.savedPlandoNames.delete(name);
+      localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
+    } else {
+      const plandoFormObj = JSON.parse(plandoSettings)
+      // Because 0 is a valid value for star spirit power costs, and -1 is the "defer to generator" setting,
+      // manually set any missing star powers to -1, so that the sliders will display correctly.
+      if (!plandoFormObj['move_costs']) {
+        plandoFormObj['move_costs'] = {};
+      }
+      if (!plandoFormObj['move_costs']['starpower']) {
+        plandoFormObj['move_costs']['starpower'] = {};
+      }
+      const powercosts = plandoFormObj['move_costs']['starpower'];
+      for (const power of STAR_SPIRIT_POWER_NAMES) {
+        if (!powercosts[power]) {
+          powercosts[power] = -1;
+        }
+      }
+      this.plandoFormGroup.setValue(plandoFormObj);
+      this.plandoFormGroup.updateValueAndValidity();
+    }
+  }
+}

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -33,9 +33,6 @@ export class PlandoSaveLoadComponent implements OnInit {
     localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
     this.saveLoadStatus = 'saved';
     this.lastPlandoName = name;
-    setTimeout(() => {
-      this.saveLoadStatus = '';
-    }, 5000);
   };
 
   public loadPlandoSettings(name: string) {
@@ -62,9 +59,6 @@ export class PlandoSaveLoadComponent implements OnInit {
       this.plandoFormGroup.updateValueAndValidity();
       this.lastPlandoName = name;
       this.saveLoadStatus = 'loaded';
-      setTimeout(() => {
-        this.saveLoadStatus = '';
-      }, 5000);
     }
   }
 
@@ -74,8 +68,5 @@ export class PlandoSaveLoadComponent implements OnInit {
     localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
     this.lastPlandoName = name;
     this.saveLoadStatus = 'deleted';
-    setTimeout(() => {
-      this.saveLoadStatus = '';
-    }, 5000);
   }
 }

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
@@ -45,7 +45,7 @@
   <h2>Star Spirit Power Costs</h2>
   <p class="text-center">If set to '?', the seed generator settings will determine the SP cost.</p>
   <div class="container" formGroupName="move_costs">
-    <div *ngFor="let power of SPRIT_POWERS;" formGroupName="starpower" class="panel">
+    <div *ngFor="let power of SPIRIT_POWERS;" formGroupName="starpower" class="panel">
       <app-tooltip-span class="row"
         [spanText]="toDisplayString(power) + ': ' + (getStarPowerCost(power) !== -1 ? getStarPowerCost(power) + ' SP' : '?')"
         tooltipText=""></app-tooltip-span>

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { Subscription } from "rxjs";
 import { pascalToVerboseString } from "src/app/utilities/stringFunctions";
 
 type Boss = {
@@ -7,15 +8,17 @@ type Boss = {
   displayName: string;
 }
 
+export const STAR_SPIRIT_POWER_NAMES: Array<string> = ['Refresh', 'Lullaby', 'StarStorm', 'ChillOut', 'Smooch', 'TimeOut', 'UpAndAway'];
+
 @Component({
   selector: 'app-plando-spirits-and-chapters',
   templateUrl: './plando-spirits-and-chapters.component.html',
   styleUrls: ['../plando-page.component.scss']
 })
-export class PlandoSpiritsAndChaptersComponent {
+export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy {
   @Input() plandoFormGroup: FormGroup;
 
-  public readonly SPRIT_POWERS: Array<string> = ['Refresh', 'Lullaby', 'StarStorm', 'ChillOut', 'Smooch', 'TimeOut', 'UpAndAway'];
+  public readonly SPIRIT_POWERS: Array<string> = STAR_SPIRIT_POWER_NAMES;
   public readonly SPIRITS: Array<string> = ['Eldstar', 'Mamar', 'Skolar', 'Muskular', 'Misstar', 'Klevar', 'Kalmar'];
   public readonly BOSSES: Array<Boss> = [
     { id: '', displayName: '' },
@@ -26,9 +29,19 @@ export class PlandoSpiritsAndChaptersComponent {
     { id: 'LavaPiranha', displayName: 'Lava Piranha' },
     { id: 'HuffNPuff', displayName: 'Huff N Puff' },
     { id: 'CrystalKing', displayName: 'Crystal King' }];
+  public spiritsSubscription: Subscription;
   public requiredSpiritsArray = Array<string>();
-
   public toDisplayString = pascalToVerboseString;
+
+  public ngOnInit(): void {
+    this.spiritsSubscription = this.plandoFormGroup.get('required_spirits').valueChanges.subscribe(val => {
+      this.requiredSpiritsArray = val;
+    })
+  }
+
+  public ngOnDestroy(): void {
+    this.spiritsSubscription.unsubscribe();
+  }
 
   public updateSpiritSelection($event: InputEvent, spirit: string) {
     if ($event.currentTarget instanceof HTMLInputElement) {
@@ -41,7 +54,7 @@ export class PlandoSpiritsAndChaptersComponent {
         }
       }
     }
-    this.plandoFormGroup.get('required_spirits').setValue(this.requiredSpiritsArray)
+    this.plandoFormGroup.get('required_spirits').setValue(this.requiredSpiritsArray);
   }
 
   public getChapterDifficulty(chapter_number: number) {

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -35,16 +35,20 @@ export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy, Aft
 
   public ngOnInit(): void {
     this.spiritsSubscription = this.plandoFormGroup.get('required_spirits').valueChanges.subscribe(val => {
-      if (!val) {
-        this.requiredSpiritsArray = [];
-      } else {
+      if (val) {
         this.requiredSpiritsArray = val;
+      } else {
+        this.requiredSpiritsArray = [];
       }
     })
   }
 
   public ngAfterContentInit(): void {
-    this.requiredSpiritsArray = this.plandoFormGroup.get('required_spirits').value;
+    if (this.plandoFormGroup.get('required_spirits').value) {
+      this.requiredSpiritsArray = this.plandoFormGroup.get('required_spirits').value;
+    } else {
+      this.requiredSpiritsArray = [];
+    }
   }
 
   public ngOnDestroy(): void {

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { AfterContentInit, AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Subscription } from "rxjs";
 import { pascalToVerboseString } from "src/app/utilities/stringFunctions";
@@ -15,7 +15,7 @@ export const STAR_SPIRIT_POWER_NAMES: Array<string> = ['Refresh', 'Lullaby', 'St
   templateUrl: './plando-spirits-and-chapters.component.html',
   styleUrls: ['../plando-page.component.scss']
 })
-export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy {
+export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy, AfterContentInit {
   @Input() plandoFormGroup: FormGroup;
 
   public readonly SPIRIT_POWERS: Array<string> = STAR_SPIRIT_POWER_NAMES;
@@ -41,6 +41,10 @@ export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy {
         this.requiredSpiritsArray = val;
       }
     })
+  }
+
+  public ngAfterContentInit(): void {
+    this.requiredSpiritsArray = this.plandoFormGroup.get('required_spirits').value;
   }
 
   public ngOnDestroy(): void {

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -35,7 +35,11 @@ export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.spiritsSubscription = this.plandoFormGroup.get('required_spirits').valueChanges.subscribe(val => {
-      this.requiredSpiritsArray = val;
+      if (!val) {
+        this.requiredSpiritsArray = [];
+      } else {
+        this.requiredSpiritsArray = val;
+      }
     })
   }
 

--- a/app/src/app/services/inputfilter.service.ts
+++ b/app/src/app/services/inputfilter.service.ts
@@ -9,7 +9,7 @@ const intRegex = /^[0-9]*$/;
 export class InputFilterService {
 
   constructor() { }
-  public filterNumericInput($event: Event, parentFormGroup: FormGroup, formControlName: string) {
+  public filterNumericInput($event: Event, parentFormGroup: FormGroup, formControlName: string[]) {
     const target = $event.target as HTMLInputElement;
     if (target.type === 'number') {
       if (target.value === '') {

--- a/app/src/app/services/inputfilter.service.ts
+++ b/app/src/app/services/inputfilter.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FormGroup } from "@angular/forms";
+import { escapeRegexChars } from "../utilities/stringFunctions";
 const intRegex = /^[0-9]*$/;
 
 @Injectable({
@@ -16,7 +17,11 @@ export class InputFilterService {
         target.dataset.prevValue = target.value;
         parentFormGroup.get(formControlName).setValue(null);
       } else if (!intRegex.test(target.value)) {
-        target.value = target.dataset.prevValue;
+        if (target.dataset.prevValue !== undefined) {
+          target.value = target.dataset.prevValue;
+        } else {
+          target.value = '';
+        }
       } else {
         const val = parseInt(target.value);
         target.dataset.prevValue = target.value;
@@ -28,6 +33,13 @@ export class InputFilterService {
         parentFormGroup.get(formControlName).setValue(parseInt(target.value));
       }
       parentFormGroup.updateValueAndValidity();
+    }
+  }
+
+  public disallowChars($event: KeyboardEvent, invalidChars: string) {
+    if (new RegExp(escapeRegexChars(invalidChars)).test($event.key)) {
+      $event.preventDefault();
+      return false;
     }
   }
 }


### PR DESCRIPTION
This PR is an enhancement to the Plandomizer Page added in #42, adding the ability to save and load plandomizer settings. All data is saved to and loaded from the browser's local storage.

- All changes on the plando creation form are now **auto-saved and auto-loaded**, allowing the user to freely navigate away while their plando building is in progress.
- Because all changes are automatically persisted, a Reset button has been added, allowing for a quick way to blank all of the inputs and start fresh, if desired:
![image](https://github.com/user-attachments/assets/e890757c-0e0d-42c3-be4e-b200000283c4)
Of course, we provide a confirmation prompt for this action, since a misclick could be disastrous otherwise:
![image](https://github.com/user-attachments/assets/dcdb1278-3abe-444b-8a41-5afee0b0cda9)
- In case users would like to save and work on multiple plandos, a new card is added at the bottom of the page to facilitate this:
![image](https://github.com/user-attachments/assets/a5b094f9-0d1c-4a6b-ac97-3f98402db1d2)
To save a plando, enter a name and click Save.
![image](https://github.com/user-attachments/assets/ad41eae6-a999-4b6f-93d8-3cdcc36ac1bd)
![image](https://github.com/user-attachments/assets/b78f374a-0f05-44f9-98e3-602366c6fc83)
Saved plandos can be loaded or deleted using the dropdown and buttons:
![image](https://github.com/user-attachments/assets/4ae9c878-6f36-4544-bdd7-9f1c138a69f1)
If no saved plandos exist, the dropdown and buttons will be hidden.

### Stray Implementation Notes

It's a pretty simple interface, and might be lacking in one or two UX features that users might expect. For example, there's no confirmation prompt if you attempt to save over an existing plando with the same name. It wouldn't be too hard to add this if desired, but I feel like it wouldn't come up too often.

Might want to also add an import feature, but I'm not sure how niche that would be either.