### PR TITLE
Plandomizer Page: Improvements to Saving/Loading, Add Plando Selection to Seed Gen Page

### DIFF
--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -66,6 +66,7 @@ import { PlandoPartyComponent } from './pages/plando-page/plando-party/plando-pa
 import { PlandoBadgesComponent } from './pages/plando-page/plando-badges/plando-badges.component';
 import { PlandoItemsComponent } from './pages/plando-page/plando-items/plando-items.component';
 import { PlandoSaveLoadComponent } from './pages/plando-page/plando-save-load/plando-save-load.component';
+import { PlandomizersComponent } from './pages/home/randomizer-page/plandomizers/plandomizers.component';
 
 const dbConfig: DBConfig  = {
   name: 'db',
@@ -126,6 +127,7 @@ const toasterConfig: Partial<GlobalConfig> = {
     PlandoBadgesComponent,
     PlandoItemsComponent,
     PlandoSaveLoadComponent,
+    PlandomizersComponent,
   ],
   imports: [
     BrowserModule,

--- a/app/src/app/pages/home/randomizer-page/goal-settings/goal-settings.component.html
+++ b/app/src/app/pages/home/randomizer-page/goal-settings/goal-settings.component.html
@@ -27,11 +27,12 @@
       <div class="setting-element slider-element">
           <app-tooltip-span [spanText]="'Star Way - Star Spirits Required: ' + getStarWaySpiritsNumber()"
                             tooltipText="Number of star spirits saved required to open the way to Ch.8. Can be set to random by bringing the slider behind 0."></app-tooltip-span>
-          <mat-slider formControlName="starWaySpiritsNeeded" (input)="goalsFormGroup.get('starWaySpiritsNeeded').setValue($event.value)" min=-1 max= 7 step="1" tickInterval="1" ></mat-slider>
+          <mat-slider formControlName="starWaySpiritsNeeded" (input)="goalsFormGroup.get('starWaySpiritsNeeded').setValue($event.value)" min=-1 max=7 step="1" tickInterval="1"
+            [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"></mat-slider>
       </div>
 
       <div class="setting-element" [ngClass]="{ 'disabled-element': isSevenOrZeroStarSpirits}">
-        <mat-slide-toggle formControlName='requireSpecificSpirits'></mat-slide-toggle>
+        <mat-slide-toggle formControlName='requireSpecificSpirits' [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"></mat-slide-toggle>
         <app-tooltip-span spanText="Require Specific Spirits"
                           tooltipText="Specific chapters must be completed to open the star way. You must visit shooting star summit to see which ones."></app-tooltip-span>
       </div>

--- a/app/src/app/pages/home/randomizer-page/goal-settings/goal-settings.component.html
+++ b/app/src/app/pages/home/randomizer-page/goal-settings/goal-settings.component.html
@@ -28,11 +28,14 @@
           <app-tooltip-span [spanText]="'Star Way - Star Spirits Required: ' + getStarWaySpiritsNumber()"
                             tooltipText="Number of star spirits saved required to open the way to Ch.8. Can be set to random by bringing the slider behind 0."></app-tooltip-span>
           <mat-slider formControlName="starWaySpiritsNeeded" (input)="goalsFormGroup.get('starWaySpiritsNeeded').setValue($event.value)" min=-1 max=7 step="1" tickInterval="1"
-            [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"></mat-slider>
+            [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"
+            matTooltipPosition="right" matTooltipShowDelay="50" matTooltipHideDelay="100"></mat-slider>
       </div>
 
       <div class="setting-element" [ngClass]="{ 'disabled-element': isSevenOrZeroStarSpirits}">
-        <mat-slide-toggle formControlName='requireSpecificSpirits' [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"></mat-slide-toggle>
+        <mat-slide-toggle formControlName='requireSpecificSpirits'
+            [matTooltip]="plandomizerSetSpirits ? 'This setting is assigned by the currently-selected Plandomizer.' : ''"
+            matTooltipPosition="right" matTooltipShowDelay="50" matTooltipHideDelay="100"></mat-slide-toggle>
         <app-tooltip-span spanText="Require Specific Spirits"
                           tooltipText="Specific chapters must be completed to open the star way. You must visit shooting star summit to see which ones."></app-tooltip-span>
       </div>

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
@@ -6,7 +6,7 @@
         <p>You have no saved Plandomizers. <a class="text-link" [routerLink]="'./plandomizer'">Go to the Plandomizer tool</a> to create or import one!</p>
     </div>
     <div class="row" *ngIf="savedPlandoNames.size > 0">
-        <label class="settings-label" for="savedPlandosSelect">Saved Plandos:</label>
+        <label class="settings-label" for="savedPlandosSelect">Select Plando:</label>
         <select name="savedPlandosSelect" #savedPlandosSelect (change)="onSavedPlandoSelect($event)">
             <option></option>
             <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
@@ -6,7 +6,7 @@
         <p>You have no saved Plandomizers. <a class="text-link" [routerLink]="'./plandomizer'">Go to the Plandomizer tool</a> to create or import one!</p>
     </div>
     <div class="row" *ngIf="savedPlandoNames.size > 0">
-        <label class="settings-label" for="savedPlandosSelect">Select Plando:</label>
+        <label class="settings-label" for="savedPlandosSelect">Select Plandomizer:</label>
         <select name="savedPlandosSelect" #savedPlandosSelect (change)="onSavedPlandoSelect($event)">
             <option></option>
             <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
@@ -15,11 +15,11 @@
     <div>
         <ng-container *ngIf="loadStatus === 'loaded'">
             <span>✔️</span>
-            <span>Applied Plando: {{this.selectedPlandoName}}</span>
+            <span>Applied Plandomizer: {{this.selectedPlandoName}}</span>
         </ng-container>
         <ng-container *ngIf="loadStatus === 'notFound'">
             <span>❌</span>
-            <span>Plando not found; it may have been deleted.</span>
+            <span>Plandomizer not found; it may have been deleted.</span>
         </ng-container>
     </div>
 </mat-card-content>

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
@@ -1,0 +1,25 @@
+<mat-card-content class=settings-card-content>
+    <div class="row">
+        <p>Apply a Plandomizer configuration to manually set move costs, item placements, and more.</p>
+    </div>
+    <div class="row" *ngIf="savedPlandoNames.size === 0">
+        <p>You have no saved Plandomizers. <a class="text-link" [routerLink]="'./plandomizer'">Go to the Plandomizer tool</a> to create or import one!</p>
+    </div>
+    <div class="row" *ngIf="savedPlandoNames.size > 0">
+        <label class="settings-label" for="savedPlandosSelect">Saved Plandos:</label>
+        <select name="savedPlandosSelect" #savedPlandosSelect (change)="onSavedPlandoSelect($event)">
+            <option></option>
+            <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
+        </select>
+    </div>
+    <div>
+        <ng-container *ngIf="loadStatus === 'loaded'">
+            <span>✔️</span>
+            <span>Applied Plando: {{this.selectedPlandoName}}</span>
+        </ng-container>
+        <ng-container *ngIf="loadStatus === 'notFound'">
+            <span>❌</span>
+            <span>Plando not found; it may have been deleted.</span>
+        </ng-container>
+    </div>
+</mat-card-content>

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.scss
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.scss
@@ -1,0 +1,12 @@
+:host {
+    font-family: gluten;
+    font-weight: 500;
+
+    p {
+        font-size: 16px;
+    }
+
+    .row {
+        width: 100%;
+    }
+}

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.spec.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlandomizersComponent } from './plandomizers.component';
+
+describe('PlandomizersComponent', () => {
+  let component: PlandomizersComponent;
+  let fixture: ComponentFixture<PlandomizersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PlandomizersComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlandomizersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from "@angular/forms";
+import { SAVED_PLANDO_NAMES_KEY } from "src/app/pages/plando-page/plando-save-load/plando-save-load.component";
+
+@Component({
+  selector: 'app-plandomizers',
+  templateUrl: './plandomizers.component.html',
+  styleUrls: ['./plandomizers.component.scss']
+})
+export class PlandomizersComponent implements OnInit {
+  @Input() public formGroup: FormGroup;
+  public savedPlandoNames: Set<String>;
+  public selectedPlandoName: string;
+  public loadStatus: string;
+
+  public ngOnInit(): void {
+    const storedNames = window.localStorage.getItem(SAVED_PLANDO_NAMES_KEY);
+    this.savedPlandoNames = storedNames ? new Set(storedNames.split(',')) : new Set();
+  }
+
+  public onSavedPlandoSelect($event: InputEvent) {
+    const plandoName = ($event.target as HTMLSelectElement).value;
+    if (!plandoName) {
+      this.formGroup.get('plandomizer').setValue(null);
+      this.loadStatus = '';
+    } else {
+      const plandoSettings = localStorage.getItem(plandoName);
+      if (!plandoSettings) {
+        this.savedPlandoNames.delete(plandoName);
+        this.loadStatus = 'notFound';
+      } else {
+        const plandoFormObj = JSON.parse(plandoSettings)
+        this.formGroup.get('plandomizer').setValue(plandoFormObj);
+        this.selectedPlandoName = plandoName;
+        this.loadStatus = 'loaded';
+      }
+    }
+  }
+
+}

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from "@angular/forms";
-import { SAVED_PLANDO_NAMES_KEY } from "src/app/pages/plando-page/plando-save-load/plando-save-load.component";
+import { SAVED_PLANDO_NAME_PREFIX, SAVED_PLANDO_NAMES_KEY } from "src/app/pages/plando-page/plando-save-load/plando-save-load.component";
 
 @Component({
   selector: 'app-plandomizers',
@@ -24,7 +24,7 @@ export class PlandomizersComponent implements OnInit {
       this.formGroup.get('plandomizer').setValue(null);
       this.loadStatus = '';
     } else {
-      const plandoSettings = localStorage.getItem(plandoName);
+      const plandoSettings = localStorage.getItem(SAVED_PLANDO_NAME_PREFIX + plandoName);
       if (!plandoSettings) {
         this.savedPlandoNames.delete(plandoName);
         this.loadStatus = 'notFound';

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormGroup } from "@angular/forms";
+import { FormControl } from "@angular/forms";
 import { SAVED_PLANDO_NAME_PREFIX, SAVED_PLANDO_NAMES_KEY } from "src/app/pages/plando-page/plando-save-load/plando-save-load.component";
 
 @Component({
@@ -8,7 +8,7 @@ import { SAVED_PLANDO_NAME_PREFIX, SAVED_PLANDO_NAMES_KEY } from "src/app/pages/
   styleUrls: ['./plandomizers.component.scss']
 })
 export class PlandomizersComponent implements OnInit {
-  @Input() public formGroup: FormGroup;
+  @Input() public plandomizerFormControl: FormControl;
   public savedPlandoNames: Set<String>;
   public selectedPlandoName: string;
   public loadStatus: string;
@@ -21,7 +21,7 @@ export class PlandomizersComponent implements OnInit {
   public onSavedPlandoSelect($event: InputEvent) {
     const plandoName = ($event.target as HTMLSelectElement).value;
     if (!plandoName) {
-      this.formGroup.get('plandomizer').setValue(null);
+      this.plandomizerFormControl.setValue(null);
       this.loadStatus = '';
     } else {
       const plandoSettings = localStorage.getItem(SAVED_PLANDO_NAME_PREFIX + plandoName);
@@ -30,7 +30,7 @@ export class PlandomizersComponent implements OnInit {
         this.loadStatus = 'notFound';
       } else {
         const plandoFormObj = JSON.parse(plandoSettings)
-        this.formGroup.get('plandomizer').setValue(plandoFormObj);
+        this.plandomizerFormControl.setValue(plandoFormObj);
         this.selectedPlandoName = plandoName;
         this.loadStatus = 'loaded';
       }

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
@@ -34,7 +34,7 @@
                 <app-difficulty-settings [difficultyFormGroup]="formGroup.get('difficulty')"></app-difficulty-settings>
                 </mat-tab>
                 <mat-tab label="Goals">
-                  <app-goal-settings [goalsFormGroup]="formGroup.get('goals')"></app-goal-settings>
+                  <app-goal-settings [goalsFormGroup]="formGroup.get('goals')" [plandoFormControl]="formGroup.get('plandomizer')"></app-goal-settings>
                 </mat-tab>
                 <mat-tab label="Stats & Gear">
                     <app-mario-settings [marioStatsFormGroup]="formGroup.get('marioStats')"></app-mario-settings>

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
@@ -23,7 +23,7 @@
                     <app-glitches-and-tricks [formGroup]="formGroup"></app-glitches-and-tricks>
                 </mat-tab>
                 <mat-tab label="Plandomizers">
-                    <app-plandomizers [formGroup]="formGroup"></app-plandomizers>
+                    <app-plandomizers [plandomizerFormControl]="plandomizerFormControl"></app-plandomizers>
                 </mat-tab>
             </mat-tab-group>
         </mat-card>
@@ -34,7 +34,7 @@
                 <app-difficulty-settings [difficultyFormGroup]="formGroup.get('difficulty')"></app-difficulty-settings>
                 </mat-tab>
                 <mat-tab label="Goals">
-                  <app-goal-settings [goalsFormGroup]="formGroup.get('goals')" [plandoFormControl]="formGroup.get('plandomizer')"></app-goal-settings>
+                  <app-goal-settings [goalsFormGroup]="formGroup.get('goals')" [plandoFormControl]="plandomizerFormControl"></app-goal-settings>
                 </mat-tab>
                 <mat-tab label="Stats & Gear">
                     <app-mario-settings [marioStatsFormGroup]="formGroup.get('marioStats')"></app-mario-settings>

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.html
@@ -22,6 +22,9 @@
                 <mat-tab label="Glitches & Tricks">
                     <app-glitches-and-tricks [formGroup]="formGroup"></app-glitches-and-tricks>
                 </mat-tab>
+                <mat-tab label="Plandomizers">
+                    <app-plandomizers [formGroup]="formGroup"></app-plandomizers>
+                </mat-tab>
             </mat-tab-group>
         </mat-card>
         <mat-card class="settings-card" [ngClass]="{ 'starting-items-tab-error': formGroup.get('marioStats').invalid}">

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.scss
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.scss
@@ -66,6 +66,11 @@
                                 background-color: $green-spirit-main !important;
                                 border-color: $green-spirit-border !important;
                               }
+
+                            > :nth-child(6) {
+                                background-color: $yellow-stat-main !important;
+                                border-color: $yellow-stat-border !important;
+                            }
                           }
                     }
                 }

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.ts
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.ts
@@ -278,7 +278,8 @@ export class RandomizerPageComponent implements OnInit, OnDestroy {
         shuffleMusic: new FormControl(-1),
         shuffleJingles: new FormControl(false),
       }),
-      glitches: new FormControl([])
+      glitches: new FormControl([]),
+      plandomizer: new FormControl()
     });
 
     this.randomPartnersMinSubscription = this.formGroup.get('partners').get('randomPartnersMin').valueChanges.pipe(

--- a/app/src/app/pages/home/randomizer-page/randomizer-page.component.ts
+++ b/app/src/app/pages/home/randomizer-page/randomizer-page.component.ts
@@ -45,6 +45,7 @@ export class RandomizerPageComponent implements OnInit, OnDestroy {
 
   public homepageLink;
   public formGroup: FormGroup
+  public plandomizerFormControl: FormControl;
   randomPartnersMinSubscription: Subscription;
 
   public isRandomizing = false;
@@ -279,8 +280,8 @@ export class RandomizerPageComponent implements OnInit, OnDestroy {
         shuffleJingles: new FormControl(false),
       }),
       glitches: new FormControl([]),
-      plandomizer: new FormControl()
     });
+    this.plandomizerFormControl = new FormControl();
 
     this.randomPartnersMinSubscription = this.formGroup.get('partners').get('randomPartnersMin').valueChanges.pipe(
       tap(() => this.formGroup.get('partners').get('randomPartnersMax').updateValueAndValidity())

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.html
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.html
@@ -27,7 +27,7 @@
     <mat-tab-group disablePagination="true" class="sub-tab" animationDuration="0" scrollToCenter>
         <mat-tab *ngFor="let loc of LOCATIONS">
             <ng-template mat-tab-label>
-                <label [ngClass]="{ 'error': itemsFormGroup.get(loc.name).invalid }">{{toDisplayString(loc.name)}}</label>
+                <label class="mat-tab-label-content" [ngClass]="{ 'error': itemsFormGroup.get(loc.name).invalid }">{{toDisplayString(loc.name)}}</label>
             </ng-template>
             <div class="panel">
                 <div class="checks-list">

--- a/app/src/app/pages/plando-page/plando-page.component.html
+++ b/app/src/app/pages/plando-page/plando-page.component.html
@@ -9,25 +9,25 @@
             <mat-tab-group disablePagination="true" animationDuration="0" scrollToCenter>
                 <mat-tab>
                     <ng-template mat-tab-label>
-                        <label>Spirits & Chapters</label>
+                        <label class="mat-tab-label-content">Spirits & Chapters</label>
                     </ng-template>
                     <app-plando-spirits-and-chapters [plandoFormGroup]="formGroup"></app-plando-spirits-and-chapters>
                 </mat-tab>
                 <mat-tab>
                     <ng-template mat-tab-label>
-                        <label [ngClass]="{'error': formGroup.get('move_costs').get('partner').invalid }">Party</label>
+                        <label class="mat-tab-label-content" [ngClass]="{'error': formGroup.get('move_costs').get('partner').invalid }">Party</label>
                     </ng-template>
                     <app-plando-party [partnerMoveCostsFormGroup]="formGroup.get('move_costs').get('partner')"></app-plando-party>
                 </mat-tab>
                 <mat-tab>
                     <ng-template mat-tab-label>
-                        <label [ngClass]="{'error': formGroup.get('move_costs').get('badge').invalid }">Badges</label>
+                        <label class="mat-tab-label-content" [ngClass]="{'error': formGroup.get('move_costs').get('badge').invalid }">Badges</label>
                     </ng-template>
                     <app-plando-badges [badgeMoveCostsFormGroup]="formGroup.get('move_costs').get('badge')"></app-plando-badges>
                 </mat-tab>
                 <mat-tab>
                     <ng-template mat-tab-label>
-                        <label [ngClass]="{'error': formGroup.get('items').invalid }">Items</label>
+                        <label class="mat-tab-label-content" [ngClass]="{'error': formGroup.get('items').invalid }">Items</label>
                     </ng-template>
                     <app-plando-items [itemsFormGroup]="formGroup.get('items')"></app-plando-items>
                 </mat-tab>

--- a/app/src/app/pages/plando-page/plando-page.component.html
+++ b/app/src/app/pages/plando-page/plando-page.component.html
@@ -32,16 +32,8 @@
                     <app-plando-items [itemsFormGroup]="formGroup.get('items')"></app-plando-items>
                 </mat-tab>
             </mat-tab-group>
-        </mat-card>
-        <mat-card class="settings-card">
-            <div class="container space-between">
-                <div class="button-container">
-                    <button [disabled]="formGroup.invalid || isValidating" class="submit" type="button" (click)="onSubmit()"
-                        [matTooltip]="formGroup.invalid ? 'Please fix the errors on the page to submit. Problems are highlighted in red.' : ''" matTooltipPosition="right">
-                        <span *ngIf="!isValidating">Download Plando File</span>
-                        <app-loading *ngIf="isValidating" [isLoading]="isValidating" [loadingText]="'Validating...'"></app-loading>
-                    </button>
-                </div>
+            <mat-divider />
+            <div class="container end">
                 <button class="yellow-button" type="button" (click)="resetPlandoForm()">
                     <span>Reset</span>
                 </button>

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -17,8 +17,8 @@
     flex-wrap: wrap;
     justify-content: center;
   }
-  .container.space-between {
-    justify-content: space-between;
+  .container.end {
+    justify-content: end;
   }
 
   .panel {

--- a/app/src/app/pages/plando-page/plando-page.component.scss
+++ b/app/src/app/pages/plando-page/plando-page.component.scss
@@ -91,6 +91,7 @@
                   color: white;
                   text-shadow: -1px 1px 0 #000, 1px 1px 0 #000, 1px -1px 0 #000,
                     -1px -1px 0 #000;
+                  cursor: pointer;
                 }
               }
               .mat-tab-label:has(> div > label.error) {
@@ -134,6 +135,7 @@
                   color: white;
                   text-shadow: -1px 1px 0 #000, 1px 1px 0 #000, 1px -1px 0 #000,
                     -1px -1px 0 #000;
+                  cursor: pointer;
                 }
 
                 .sub-tab .mat-tab-label-content {

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -5,8 +5,9 @@ import { CheckType, LOCATIONS_LIST, PLANDO_ITEMS_LIST } from "./plando-items/pla
 import { escapeRegexChars } from "src/app/utilities/stringFunctions";
 import { STAR_SPIRIT_POWER_NAMES } from "./plando-spirits-and-chapters/plando-spirits-and-chapters.component";
 
-export const MAX_FP_COST = 75;
-export const MAX_BP_COST = 10;
+export const MAX_FP_COST: number = 75;
+export const MAX_BP_COST: number = 10;
+export const DEFAULT_PLANDOMIZER_KEY: string = 'default_plandomizer';
 
 const plandoItemSet = new Set(PLANDO_ITEMS_LIST);
 const manualTrapRegex = new RegExp('^TRAP \\((' + PLANDO_ITEMS_LIST.slice(4).map(escapeRegexChars).join('|') + ')\\)$');
@@ -119,7 +120,7 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
       }
       (this.formGroup.get('items') as FormGroup).addControl(location.name, locationFormGroup);
     }
-    localStorage.setItem('default_plandomizer', JSON.stringify(this.formGroup.getRawValue()));
+    localStorage.setItem(DEFAULT_PLANDOMIZER_KEY, JSON.stringify(this.formGroup.getRawValue()));
     const savedFormObj = localStorage.getItem('autosavePlandoSettings');
     if (savedFormObj) {
       this.formGroup.setValue(JSON.parse(savedFormObj));

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -119,6 +119,7 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
       }
       (this.formGroup.get('items') as FormGroup).addControl(location.name, locationFormGroup);
     }
+    localStorage.setItem('default_plandomizer', JSON.stringify(this.formGroup.getRawValue()));
     const savedFormObj = localStorage.getItem('autosavePlandoSettings');
     if (savedFormObj) {
       this.formGroup.setValue(JSON.parse(savedFormObj));

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -137,7 +137,7 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
   }
 
   public resetPlandoForm() {
-    if (confirm('This will reset all plando settings. Are you sure?')) {
+    if (confirm('This will clear and reset ALL plando settings. Are you sure?')) {
       this.formGroup.reset();
       for (const power of STAR_SPIRIT_POWER_NAMES) {
         this.formGroup.get('move_costs').get('starpower').get(power).setValue(-1);
@@ -146,50 +146,4 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
     }
   }
 
-  public onSubmit() {
-    this.isValidating = true;
-    let plandoFormObj = this.formGroup.getRawValue()
-    // The slider inputs don't play nicely with setting the form control value to "null"
-    // when they're at the lowest setting; handle those values here by removing them instead.
-    const difficultySettings = plandoFormObj['difficulty'];
-    for (const chapter in difficultySettings) {
-      if (difficultySettings[chapter] === 0) {
-        delete difficultySettings[chapter];
-      }
-    }
-    const powercosts = plandoFormObj['move_costs']['starpower'];
-    for (const power in powercosts) {
-      if (powercosts[power] === -1) {
-        delete powercosts[power];
-      }
-    }
-
-    // Remove all null and empty values.
-    const tidyObj = (obj) => {
-      return Object.fromEntries(Object.entries(obj).flatMap(([k, v]) => {
-        if (v === null
-          || (typeof v === 'object' && Object.keys(v).length === 0)
-          || (typeof v === 'string' && v.trim() === '')) {
-          return [];
-        }
-        if (typeof v !== 'object' || (Array.isArray(v) && v.length > 0)) {
-          return [[k, v]];
-        }
-        v = tidyObj(v);
-        if (Object.keys(v).length === 0) {
-          return []
-        } else {
-          return [[k, v]];
-        }
-      }));
-    }
-    const a = document.createElement('a');
-    const plandoFile = new Blob([JSON.stringify(tidyObj(plandoFormObj))], { type: 'application/json' });
-    a.href = URL.createObjectURL(plandoFile);
-    const dateParts = new Date().toISOString().split('T');
-    const datetime = dateParts[0] + '_' + dateParts[1].substring(0, 8).replace(/:/g, '');
-    a.download = 'pm64-plando-' + datetime + '.json';
-    a.click();
-    this.isValidating = false;
-  }
 }

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -21,8 +21,8 @@
                 <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
             </select>
             <div>
-                <button class="yellow-button" type="button" [disabled]="savedPlandosSelect.value === ''" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
-                <button class="yellow-button" type="button" [disabled]="savedPlandosSelect.value === ''" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
+                <button class="yellow-button" type="button" [disabled]="saveLoadFormGroup.get('savedPlandoNameSelect').value === ''" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
+                <button class="yellow-button" type="button" [disabled]="saveLoadFormGroup.get('savedPlandoNameSelect').value === ''" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
                 <ng-container *ngIf="saveLoadStatus === 'loaded'">
                     <span>✔️</span>
                     <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -7,7 +7,7 @@
         <h3>Save Plando</h3>
         <div class="row">
             <label for="plandoName">Plando Name:</label>
-            <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',_')" />
+            <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',_')" [maxlength]="MAX_PLANDO_NAME_LENGTH" />
             <button class="yellow-button" type="button"
                 [disabled]="plandoName.value.trim() === '' || plandoFormGroup.invalid"
                 [matTooltip]="plandoFormGroup.invalid ? 'Please fix the errors on the page before saving. Problems are highlighted in red.' : ''"
@@ -31,8 +31,11 @@
             <ng-container *ngIf="importStatus === 'success'">
                 <span class="status">✔️ Plando settings imported successfully!</span>
             </ng-container>
-            <ng-container *ngIf="importStatus === 'failure'">
+            <ng-container *ngIf="importStatus === 'invalid'">
                 <span class="status">❌ Import failed. Ensure that the file is in the correct format.</span>
+            </ng-container>
+            <ng-container *ngIf="importStatus === 'exists'">
+                <span class="status">❌ Import failed. A plando with this name already exists.</span>
             </ng-container>
         </div>
     </div>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -1,6 +1,6 @@
 <h2>Save & Load Plando Configs</h2>
 
-<p>All current changes will be auto-saved, and will auto-load when returning to this page.</p>
+<p class="text-center">All current changes will be auto-saved, and will auto-load when returning to this page.</p>
 <div class="container" [formGroup]="saveLoadFormGroup">
 
     <div class="panel">
@@ -10,30 +10,29 @@
             <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',_')" />
             <button class="yellow-button" type="button"
                 [disabled]="plandoName.value.trim() === '' || plandoFormGroup.invalid"
-                [matTooltip]="plandoFormGroup.invalid ? 'Please fix the errors on the page to save. Problems are highlighted in red.' : ''"
+                [matTooltip]="plandoFormGroup.invalid ? 'Please fix the errors on the page before saving. Problems are highlighted in red.' : ''"
                 matTooltipPosition="right" (click)="savePlandoSettings(plandoName.value)">
                 <span>Save</span>
             </button>
+        </div>
+        <div class="row">
             <ng-container *ngIf="saveLoadStatus === 'saved'">
-                <span>✔️</span>
-                <span class="success">Plando Saved!</span>
+                <span class="status">✔️ Plando Saved!</span>
             </ng-container>
         </div>
     </div>
 
     <div class="panel">
-        <h3>Import Plando</h3>
+        <h3>Import Plando Settings</h3>
         <div class="row">
             <button class="yellow-button" type="button" (click)="importPlandoSettings()"><span>Import</span></button>
         </div>
         <div class="row">
             <ng-container *ngIf="importStatus === 'success'">
-                <span>✔️</span>
-                <span class="success">Plando settings imported successfully!</span>
+                <span class="status">✔️ Plando settings imported successfully!</span>
             </ng-container>
             <ng-container *ngIf="importStatus === 'failure'">
-                <span>❌</span>
-                <span class="success">Import failed. Ensure that the file is in the correct format.</span>
+                <span class="status">❌ Import failed. Ensure that the file is in the correct format.</span>
             </ng-container>
         </div>
     </div>
@@ -53,16 +52,13 @@
         </div>
         <div class="row">
             <ng-container *ngIf="saveLoadStatus === 'loaded'">
-                <span>✔️</span>
-                <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>
+                <span class="status">✔️ Loaded Plando: {{this.lastPlandoName}}</span>
             </ng-container>
             <ng-container *ngIf="saveLoadStatus === 'deleted'">
-                <span>✔️</span>
-                <span class="success">Deleted Plando: {{this.lastPlandoName}}</span>
+                <span class="status">✔️ Deleted Plando: {{this.lastPlandoName}}</span>
             </ng-container>
             <ng-container *ngIf="saveLoadStatus === 'notFound'">
-                <span>❌</span>
-                <span>Plando not found; it may have been deleted. It has been removed from the list.</span>
+                <span class="status">❌ Plando not found; it may have been deleted. It has been removed from the list.</span>
             </ng-container>
         </div>
         <div class="row" *ngIf="savedPlandoNames.size === 0">There are no saved plandos.</div>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -23,13 +23,13 @@
     </div>
 
     <div class="panel">
-        <h3>Import Plando Settings</h3>
+        <h3>Import Plando</h3>
         <div class="row">
             <button class="yellow-button" type="button" (click)="importPlandoSettings()"><span>Import</span></button>
         </div>
         <div class="row">
             <ng-container *ngIf="importStatus === 'success'">
-                <span class="status">✔️ Plando settings imported successfully!</span>
+                <span class="status">✔️ Plando imported successfully!</span>
             </ng-container>
             <ng-container *ngIf="importStatus === 'invalid'">
                 <span class="status">❌ Import failed. Ensure that the file is in the correct format.</span>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -7,7 +7,7 @@
 
         <div class="row start">
             <label for="plandoName">Plando Name:</label>
-            <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',')" />
+            <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',_')" />
             <button class="yellow-button" type="button" [disabled]="plandoName.value.trim() === ''" (click)="savePlandoSettings(plandoName.value)"><span>Save</span></button>
             <ng-container *ngIf="saveLoadStatus === 'saved'">
                 <span>✔️</span>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.html
@@ -1,21 +1,46 @@
 <h2>Save & Load Plando Configs</h2>
-<div class="container">
-    <div class="panel" [formGroup]="saveLoadFormGroup">
-        <div class="row start">
-            <p>All current changes will be auto-saved, and will auto-load when returning to this page. Use the controls below if you'd like to create and save multiple plandos.</p>
-        </div>
 
-        <div class="row start">
+<p>All current changes will be auto-saved, and will auto-load when returning to this page.</p>
+<div class="container" [formGroup]="saveLoadFormGroup">
+
+    <div class="panel">
+        <h3>Save Plando</h3>
+        <div class="row">
             <label for="plandoName">Plando Name:</label>
             <input name="plandoName" formControlName="plandoName" #plandoName (keydown)="this.inputFilters.disallowChars($event, ',_')" />
-            <button class="yellow-button" type="button" [disabled]="plandoName.value.trim() === ''" (click)="savePlandoSettings(plandoName.value)"><span>Save</span></button>
+            <button class="yellow-button" type="button"
+                [disabled]="plandoName.value.trim() === '' || plandoFormGroup.invalid"
+                [matTooltip]="plandoFormGroup.invalid ? 'Please fix the errors on the page to save. Problems are highlighted in red.' : ''"
+                matTooltipPosition="right" (click)="savePlandoSettings(plandoName.value)">
+                <span>Save</span>
+            </button>
             <ng-container *ngIf="saveLoadStatus === 'saved'">
                 <span>✔️</span>
                 <span class="success">Plando Saved!</span>
             </ng-container>
         </div>
+    </div>
 
-        <div class="row start" *ngIf="savedPlandoNames.size > 0">
+    <div class="panel">
+        <h3>Import Plando</h3>
+        <div class="row">
+            <button class="yellow-button" type="button" (click)="importPlandoSettings()"><span>Import</span></button>
+        </div>
+        <div class="row">
+            <ng-container *ngIf="importStatus === 'success'">
+                <span>✔️</span>
+                <span class="success">Plando settings imported successfully!</span>
+            </ng-container>
+            <ng-container *ngIf="importStatus === 'failure'">
+                <span>❌</span>
+                <span class="success">Import failed. Ensure that the file is in the correct format.</span>
+            </ng-container>
+        </div>
+    </div>
+
+    <div class="panel">
+        <h3>Manage Saved Plandos</h3>
+        <div class="row" *ngIf="savedPlandoNames.size > 0">
             <label for="savedPlandosSelect">Saved Plandos:</label>
             <select name="savedPlandosSelect" #savedPlandosSelect formControlName="savedPlandoNameSelect">
                 <option *ngFor="let plandoName of savedPlandoNames" [value]="plandoName">{{plandoName}}</option>
@@ -23,15 +48,23 @@
             <div>
                 <button class="yellow-button" type="button" [disabled]="saveLoadFormGroup.get('savedPlandoNameSelect').value === ''" (click)="loadPlandoSettings(savedPlandosSelect.value)"><span>Load</span></button>
                 <button class="yellow-button" type="button" [disabled]="saveLoadFormGroup.get('savedPlandoNameSelect').value === ''" (click)="deletePlandoSettings(savedPlandosSelect.value)"><span>Delete</span></button>
-                <ng-container *ngIf="saveLoadStatus === 'loaded'">
-                    <span>✔️</span>
-                    <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>
-                </ng-container>
-                <ng-container *ngIf="saveLoadStatus === 'deleted'">
-                    <span>✔️</span>
-                    <span class="success">Deleted Plando: {{this.lastPlandoName}}</span>
-                </ng-container>
+                <button class="yellow-button" type="button" [disabled]="saveLoadFormGroup.get('savedPlandoNameSelect').value === ''" (click)="exportPlandoSettings(savedPlandosSelect.value)"><span>Export</span></button>
             </div>
         </div>
+        <div class="row">
+            <ng-container *ngIf="saveLoadStatus === 'loaded'">
+                <span>✔️</span>
+                <span class="success">Loaded Plando: {{this.lastPlandoName}}</span>
+            </ng-container>
+            <ng-container *ngIf="saveLoadStatus === 'deleted'">
+                <span>✔️</span>
+                <span class="success">Deleted Plando: {{this.lastPlandoName}}</span>
+            </ng-container>
+            <ng-container *ngIf="saveLoadStatus === 'notFound'">
+                <span>❌</span>
+                <span>Plando not found; it may have been deleted. It has been removed from the list.</span>
+            </ng-container>
+        </div>
+        <div class="row" *ngIf="savedPlandoNames.size === 0">There are no saved plandos.</div>
     </div>
 </div>

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
@@ -1,11 +1,17 @@
 :host {
     .panel {
         flex: 1 1 31%;
+        min-height: 210px;
+        align-items: start;
     }
     select {
         min-width: 15rem;
     }
     button {
         margin: 0.5rem;
+    }
+    .status {
+        position:absolute;
+        max-width: 30%;
     }
 }

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
@@ -1,6 +1,6 @@
 :host {
     .panel {
-        flex: 0 1 100%;
+        flex: 1 1 31%;
     }
     select {
         min-width: 15rem;

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.scss
@@ -12,6 +12,12 @@
     }
     .status {
         position:absolute;
-        max-width: 30%;
+        max-width: 60%;
+        @media screen and (min-width:637px) and (max-width: 1399px) {
+            max-width: 30%;
+        }
+        @media screen and (min-width:1752px) {
+            max-width: 30%;
+        }
     }
 }

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -164,9 +164,7 @@ export class PlandoSaveLoadComponent implements OnInit {
         this.saveLoadFormGroup.get('plandoName').setValue(plandoName);
         this.savePlandoSettings(plandoName);
       } catch (e) {
-        if (e.message && e.message.length <= 7) {
-          this.importStatus = e.message;
-        }
+        this.importStatus = e.message;
       }
     }
     input.click();

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -3,6 +3,8 @@ import { FormControl, FormGroup } from "@angular/forms";
 import { STAR_SPIRIT_POWER_NAMES } from "../plando-spirits-and-chapters/plando-spirits-and-chapters.component";
 import { InputFilterService } from "src/app/services/inputfilter.service";
 
+export const SAVED_PLANDO_NAMES_KEY = 'savedPlandoNames';
+
 @Component({
   selector: 'app-plando-save-load',
   templateUrl: './plando-save-load.component.html',
@@ -12,14 +14,13 @@ export class PlandoSaveLoadComponent implements OnInit {
   @Input() plandoFormGroup: FormGroup;
 
   constructor(public inputFilters: InputFilterService) { };
-  private readonly SAVED_PLANDO_NAMES_KEY = 'savedPlandoNames';
   public savedPlandoNames: Set<string>;
   public saveLoadFormGroup: FormGroup;
   public saveLoadStatus: string;
   public lastPlandoName: string;
 
   public ngOnInit(): void {
-    const savedNames = localStorage.getItem(this.SAVED_PLANDO_NAMES_KEY);
+    const savedNames = localStorage.getItem(SAVED_PLANDO_NAMES_KEY);
     this.savedPlandoNames = savedNames ? new Set(savedNames.split(',')) : new Set();
     this.saveLoadFormGroup = new FormGroup({
       plandoName: new FormControl<string>(''),
@@ -30,7 +31,7 @@ export class PlandoSaveLoadComponent implements OnInit {
   public savePlandoSettings(name: string) {
     localStorage.setItem(name, JSON.stringify(this.plandoFormGroup.getRawValue()))
     this.savedPlandoNames.add(name);
-    localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
+    localStorage.setItem(SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
     this.saveLoadStatus = 'saved';
     this.lastPlandoName = name;
   };
@@ -65,7 +66,7 @@ export class PlandoSaveLoadComponent implements OnInit {
   public deletePlandoSettings(name: string) {
     this.savedPlandoNames.delete(name);
     localStorage.removeItem(name);
-    localStorage.setItem(this.SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
+    localStorage.setItem(SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
     this.lastPlandoName = name;
     this.saveLoadStatus = 'deleted';
   }

--- a/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
+++ b/app/src/app/pages/plando-page/plando-save-load/plando-save-load.component.ts
@@ -4,6 +4,7 @@ import { STAR_SPIRIT_POWER_NAMES } from "../plando-spirits-and-chapters/plando-s
 import { InputFilterService } from "src/app/services/inputfilter.service";
 
 export const SAVED_PLANDO_NAMES_KEY = 'savedPlandoNames';
+export const SAVED_PLANDO_NAME_PREFIX = 'plando_';
 
 @Component({
   selector: 'app-plando-save-load',
@@ -29,7 +30,7 @@ export class PlandoSaveLoadComponent implements OnInit {
   }
 
   public savePlandoSettings(name: string) {
-    localStorage.setItem(name, JSON.stringify(this.plandoFormGroup.getRawValue()))
+    localStorage.setItem(SAVED_PLANDO_NAME_PREFIX + name, JSON.stringify(this.plandoFormGroup.getRawValue()))
     this.savedPlandoNames.add(name);
     localStorage.setItem(SAVED_PLANDO_NAMES_KEY, Array.from(this.savedPlandoNames).join(','));
     this.saveLoadStatus = 'saved';
@@ -37,7 +38,7 @@ export class PlandoSaveLoadComponent implements OnInit {
   };
 
   public loadPlandoSettings(name: string) {
-    const plandoSettings = localStorage.getItem(name);
+    const plandoSettings = localStorage.getItem(SAVED_PLANDO_NAME_PREFIX + name);
     if (!plandoSettings) {
       this.deletePlandoSettings(name);
     } else {

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
@@ -1,8 +1,7 @@
 <div [formGroup]="plandoFormGroup">
   <h2>Required Spirits and Difficulty Scaling</h2>
   <p class="text-center">
-    If "Require Specific Spirits" is enabled in the seed generator, the selected
-    Star Spirits will be required for completion.
+    Selected Star Spirits will be required for completion. If no spirits are selected, the seed generator settings will determine the required Star Spirits.
   </p>
   <div class="container">
     <div *ngFor="let spirit of SPIRITS; let i = index; let requiredSpirits = requiredSpirits" class="panel">

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
@@ -13,7 +13,8 @@
             type="checkbox"
             class="hidden"
             value="{{ spirit }}"
-            (change)="updateSpiritSelection($event, spirit)" />
+            (change)="updateSpiritSelection($event, spirit)"
+            [checked]="requiredSpiritsArray.includes(spirit)" />
           <img
             src="{{
               '/assets/images/plando/' +

--- a/app/src/app/services/inputfilter.service.ts
+++ b/app/src/app/services/inputfilter.service.ts
@@ -37,7 +37,7 @@ export class InputFilterService {
   }
 
   public disallowChars($event: KeyboardEvent, invalidChars: string) {
-    if (new RegExp(escapeRegexChars(invalidChars)).test($event.key)) {
+    if (new RegExp('[' + escapeRegexChars(invalidChars) + ']').test($event.key)) {
       $event.preventDefault();
       return false;
     }


### PR DESCRIPTION
This PR does a bit of an overhaul to the UX of the plandomizer page with respect to its output and the primary function of the page.

Put simply, I realized that if we're saving plando configurations to local storage, there's really no need to make a user download a JSON file and attach it to their seed generator requests. We can just handle it for them! 🙂

### Seed Generator Page: Plandomizers List

![image](https://github.com/user-attachments/assets/13d86044-63e5-4c18-871e-64b6a581e8b9)
A new tab is added to the Randomizer Settings card on the seed generator page. Tentatively named "Plandomizers".

![image](https://github.com/user-attachments/assets/1a19761a-2114-441b-b658-1adb844447fa)
This tab lists any plandomizer configurations that the user has in their local storage, as well as a one-sentence explanation of what a plandomizer does.

This user doesn't have any, so we provide a link to the plando creation page.

### Plandomizer Page: Layout Changes

![image](https://github.com/user-attachments/assets/9e13fa18-3f01-473c-ae4a-c0dd753fed7f)
With this new approach to plando integration, we no longer need the giant submit button on a separate card. The reset button is now tucked into the corner of the main plando card.

Saving to localstorage is now the primary function of this tool, so the Save & Load Plando Configs card has been expanded and emphasized compared to the previous revision.

![image](https://github.com/user-attachments/assets/acd8d116-5acf-403b-94a4-7f0317eb009f)
The validation check has been moved to the Save button. Probably should have been there anyway, haha.

![image](https://github.com/user-attachments/assets/a4931af8-91a8-493b-9ded-e5a13964c6b1)
On a successful save, the Saved Plandos dropdown appears, along with the controls for managing saved plandos.

![image](https://github.com/user-attachments/assets/bbbcaa83-27e3-4276-aaf1-4fd4efcf3296)
The controls are enabled when a saved plando is selected. Load and Delete function the same as before. The Export button now carries the functionality of the original Download Plando File button, allowing users to share plandos with one another more easily, or manually generate seeds.

![image](https://github.com/user-attachments/assets/2cc02d76-08ab-45dc-aec3-a12d43a19e9f)
Files are saved as sparse representations of the FormGroup object, same as before. The filename will now be the saved plando name.

![image](https://github.com/user-attachments/assets/d98ee04c-8e22-4412-aa90-0acde2e071a5)
The Import button will accept any JSON file, and on a successful import, the imported settings will be applied, and a saved plando entry will be created with the specified name.

![image](https://github.com/user-attachments/assets/fdd9a9c4-a885-4b83-b0ff-8323c82d7665)
Name collisions are prohibited; this prevents accidental overwriting of data. It's just a couple clicks to delete the existing Plando if required.

![image](https://github.com/user-attachments/assets/11caa4d9-9582-4c43-a344-b47308f066dd)
Any file that does not fit the plando format will be rejected, with an error message indicating as such.

Going back to the seed generator page, now...

![image](https://github.com/user-attachments/assets/fa53f70b-0baf-497f-8b78-3b22e39d1c9b)
Our saved plando now shows up. And as a little extra bonus...

![image](https://github.com/user-attachments/assets/cf251c7c-847d-4388-8cb1-4a5d0199b26c)
This PR also includes a bit of extra logic to prevent a settings mismatch.

If we select a plandomizer that has a value for the `required_spirits` field...

![image](https://github.com/user-attachments/assets/c5491a5b-6a4b-4a07-b63f-9b9506b669af)
We update the relevant form controls in the Goals tab, and disable them to prevent editing.

![image](https://github.com/user-attachments/assets/533c2c27-cbb7-4f4c-af3e-99791d652603)
A tooltip is provided on the controls to explain why they're locked.

As part of this logic, this PR also adds an extra FormControl to the overarching randomizer settings request FormGroup. From what I can see, this should have no effect, and should make it easier to attach the plando settings when making the seed generation request.

### Stray Implementation Notes

- This PR also fixes a blunder I made with respect to the Save/Load logic; previously, values were saved to local storage with the names as entered, verbatim. It would be possible to overwrite anything in local storage because of this! If someone named their plando "presets", they would overwrite all of their seed generator presets. Whoops! I've since added a prefix to prevent any collisions with other local storage uses in the app, and some extra sanitation to prevent troublesome characters (commas, mostly) from sneaking their way in.
- I'm not super happy with a couple aspects of the presentation at present, but I can't think of any great alternatives. Two things stick out to me:
  - The reset button is kinda ugly and lonely sticking on the corner of the plando settings card. It might be worth adding tab-specific reset buttons, and then the global reset button can sit beneath it outside the tab body.
  - The lonely import panel with its single button; conceptually I think it would fit better in the Manage Saved Plandos panel, but then that panel is getting a bit crowded, plus the import button will move around when the Load/Delete/Export buttons change their visibility. UI elements moving around is a big pet peeve of mine, so I opted for this approach instead.
- I'm not sure if the `Plandomizers` tab on the Randomizer Settings card might be confusing for users uninterested in it. It's also pretty sparse to get an entire tab to itself, but there didn't seem to be a better place to put it without giving it too much visual prominence and making its purpose even more confusing in the process.