### PR TITLE
Plandomizer Page: Autosave on Unload

### DIFF
--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -125,6 +125,7 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
     if (savedFormObj) {
       this.formGroup.setValue(JSON.parse(savedFormObj));
     }
+    window.addEventListener('beforeunload', () => this.ngOnDestroy());
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
Currently, the Plandomizer page will autosave the current changes to local storage when navigating to a different page. It does not autosave when the tab is closed or reloaded. This PR adds logic for this.

This will not cover the narrow use cases where `beforeunload` is not called, such as a mobile browser being killed in the background, but those are edge cases anyway.