### PR TITLE
Plandomizer: Disallow Trap Coins and Add Autocomplete for Trap Items

### DIFF
--- a/app/src/app/pages/plando-page/plando-constants.ts
+++ b/app/src/app/pages/plando-page/plando-constants.ts
@@ -1897,6 +1897,14 @@ export const PLANDO_ITEMS_LIST: Array<string> = [
     "ZapTap"
 ];
 
+const ILLEGAL_TRAP_ITEMS: Set<string> = new Set([
+    "TRAP",
+    "NonProgression",
+    "Consumable",
+    "Coin"]);
+
+export const LEGAL_TRAP_ITEMS: Array<string> = Array.from(PLANDO_ITEMS_LIST.filter((item) => !ILLEGAL_TRAP_ITEMS.has(item)));
+
 export const LEGAL_MASS_FILL_ITEMS: Set<string> = new Set([
     "TRAP",
     "NonProgression",

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -38,7 +38,7 @@ export class PlandoItemsComponent {
   public readonly LOCATIONS: Array<Location> = LOCATIONS_LIST;
   public readonly PLANDO_ITEMS: Array<string> = PLANDO_ITEMS_LIST.slice();
   public readonly MASS_FILL_ITEMS: Set<string> = LEGAL_MASS_FILL_ITEMS;
-  public readonly LEGAL_TRAP_ITEMS: Set<string> = new Set(LEGAL_TRAP_ITEMS.map((i) => 'TRAP (' + i + ')'));
+  public readonly LEGAL_TRAP_ITEMS: Set<string> = new Set(['TRAP'].concat(LEGAL_TRAP_ITEMS.map((i) => 'TRAP (' + i + ')')));
   public readonly CHECK_TYPES_DISPLAY_MAP: Record<CheckType, string> = CHECK_TYPES_DISPLAY_MAPPING;
   constructor(public inputFilters: InputFilterService) { };
   // Multicoin and super blocks not supported yet. Always filter them for now.
@@ -124,7 +124,7 @@ export class PlandoItemsComponent {
   }
 
   private _filter(initialOptions: Array<string>, value: string): void {
-    if (value.startsWith('TRAP')) {
+    if (value.toLowerCase().startsWith('trap')) {
       initialOptions = Array.from(this.LEGAL_TRAP_ITEMS);
     }
     const regexes = value.toLowerCase().split(/\s/g).filter(s => s.trim() !== '').map(s => new RegExp(escapeRegexChars(s), 'i'));

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -48,7 +48,6 @@ export class PlandoItemsComponent {
   public massFillCheckTypes = Object.values(CheckType).filter(val => !this.filteredTypes.includes(val) && val !== CheckType.NORMAL);
   public filteredItems: string[] = this.PLANDO_ITEMS.slice();
   public searchText: FormControl;
-  public settingTrap: boolean = false;
 
   public updateAutoCompleteFilter($event: InputEvent) {
     this._filter(this.PLANDO_ITEMS.slice(), ($event.target as HTMLInputElement).value);
@@ -127,9 +126,6 @@ export class PlandoItemsComponent {
   private _filter(initialOptions: Array<string>, value: string): void {
     if (value.startsWith('TRAP')) {
       initialOptions = Array.from(this.LEGAL_TRAP_ITEMS);
-      this.settingTrap = true;
-    } else {
-      this.settingTrap = false;
     }
     const regexes = value.toLowerCase().split(/\s/g).filter(s => s.trim() !== '').map(s => new RegExp(escapeRegexChars(s), 'i'));
     this.filteredItems = initialOptions.filter(item => regexes.every(reg => reg.test(item)));

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -3,7 +3,7 @@ import { FormControl, FormGroup } from "@angular/forms";
 import { MatSlideToggleChange } from "@angular/material/slide-toggle";
 import { InputFilterService } from "src/app/services/inputfilter.service";
 import { escapeRegexChars, pascalToVerboseString } from "src/app/utilities/stringFunctions";
-import { CHECK_TYPES_DISPLAY_MAPPING, CheckType, LEGAL_MASS_FILL_ITEMS, Location, LOCATIONS_LIST, PLANDO_ITEMS_LIST, VANILLA_ITEMS } from "../plando-constants";
+import { CHECK_TYPES_DISPLAY_MAPPING, CheckType, LEGAL_MASS_FILL_ITEMS, LEGAL_TRAP_ITEMS, Location, LOCATIONS_LIST, PLANDO_ITEMS_LIST, VANILLA_ITEMS } from "../plando-constants";
 import { manualTrapRegex } from "../plando-page.component";
 
 const possessiveRegex = /(Mario|Peach|Boo|Guy|Troopa|King|Bowser|Rowf|Merlow|Merluvlee|Tubba|Kolorado|Bow|Lily|Petunia|Rosie)s /g;
@@ -38,6 +38,7 @@ export class PlandoItemsComponent {
   public readonly LOCATIONS: Array<Location> = LOCATIONS_LIST;
   public readonly PLANDO_ITEMS: Array<string> = PLANDO_ITEMS_LIST.slice();
   public readonly MASS_FILL_ITEMS: Set<string> = LEGAL_MASS_FILL_ITEMS;
+  public readonly LEGAL_TRAP_ITEMS: Set<string> = new Set(LEGAL_TRAP_ITEMS.map((i) => 'TRAP (' + i + ')'));
   public readonly CHECK_TYPES_DISPLAY_MAP: Record<CheckType, string> = CHECK_TYPES_DISPLAY_MAPPING;
   constructor(public inputFilters: InputFilterService) { };
   // Multicoin and super blocks not supported yet. Always filter them for now.
@@ -47,6 +48,7 @@ export class PlandoItemsComponent {
   public massFillCheckTypes = Object.values(CheckType).filter(val => !this.filteredTypes.includes(val) && val !== CheckType.NORMAL);
   public filteredItems: string[] = this.PLANDO_ITEMS.slice();
   public searchText: FormControl;
+  public settingTrap: boolean = false;
 
   public updateAutoCompleteFilter($event: InputEvent) {
     this._filter(this.PLANDO_ITEMS.slice(), ($event.target as HTMLInputElement).value);
@@ -113,8 +115,8 @@ export class PlandoItemsComponent {
           }
         } else {
           this.itemsFormGroup.get(check).setValue(fillItem);
-          if (fillItem === '' && this.itemsFormGroup.get([check[0],check[1],'price'])) {
-            this.itemsFormGroup.get([check[0],check[1],'price']).setValue('');
+          if (fillItem === '' && this.itemsFormGroup.get([check[0], check[1], 'price'])) {
+            this.itemsFormGroup.get([check[0], check[1], 'price']).setValue('');
           }
         }
       }
@@ -123,6 +125,12 @@ export class PlandoItemsComponent {
   }
 
   private _filter(initialOptions: Array<string>, value: string): void {
+    if (value.startsWith('TRAP')) {
+      initialOptions = Array.from(this.LEGAL_TRAP_ITEMS);
+      this.settingTrap = true;
+    } else {
+      this.settingTrap = false;
+    }
     const regexes = value.toLowerCase().split(/\s/g).filter(s => s.trim() !== '').map(s => new RegExp(escapeRegexChars(s), 'i'));
     this.filteredItems = initialOptions.filter(item => regexes.every(reg => reg.test(item)));
   }

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -1,16 +1,16 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from "@angular/forms";
-import { BADGE_LIST } from "./plando-badges/plando-badges.component";
 import { escapeRegexChars } from "src/app/utilities/stringFunctions";
+import { BADGE_LIST } from "./plando-badges/plando-badges.component";
+import { CheckType, LEGAL_TRAP_ITEMS, LOCATIONS_LIST, PLANDO_ITEMS_LIST } from "./plando-constants";
 import { STAR_SPIRIT_POWER_NAMES } from "./plando-spirits-and-chapters/plando-spirits-and-chapters.component";
-import { CheckType, LOCATIONS_LIST, PLANDO_ITEMS_LIST } from "./plando-constants";
 
 export const MAX_FP_COST: number = 75;
 export const MAX_BP_COST: number = 10;
 export const DEFAULT_PLANDOMIZER_KEY: string = 'default_plandomizer';
 
 const plandoItemSet = new Set(PLANDO_ITEMS_LIST);
-export const manualTrapRegex = new RegExp('^TRAP \\((' + PLANDO_ITEMS_LIST.slice(3).map(escapeRegexChars).join('|') + ')\\)$');
+export const manualTrapRegex = new RegExp('^TRAP \\((' + LEGAL_TRAP_ITEMS.map(escapeRegexChars).join('|') + ')\\)$');
 
 @Component({
   selector: 'app-plando-page',


### PR DESCRIPTION
This PR fixes a logic error where `TRAP (Coin)` was erroneously considered a valid item. The logic for defining legal and illegal trap items has been made a bit less kludgy.

In addition, the autocomplete has been slightly refactored; now when a user enters "TRAP" the autocomplete entries will shift to a list of valid trap assignments. This should make manual trap assignment much easier. 