### PR TITLE
Plandomizer: Assign Starting Partner Settings When Selecting Plando

### DIFF
--- a/app/src/app/pages/home/randomizer-page/partners/partners.component.html
+++ b/app/src/app/pages/home/randomizer-page/partners/partners.component.html
@@ -24,7 +24,7 @@
         </div>
         <mat-divider></mat-divider>
         <div class="setting-element full-width-element">
-            <mat-slide-toggle formControlName='startWithRandomPartners'></mat-slide-toggle>
+            <mat-slide-toggle formControlName='startWithRandomPartners' plandoAssignable></mat-slide-toggle>
             <app-tooltip-span
                 spanText="Start With Random Partners"
                  tooltipText="Off: Start the game with a custom selection of starting partners
@@ -40,6 +40,7 @@
                         max="8"
                         formControlName='randomPartnersMin'
                         (blur)="onRandomPartnersMinBlur()"
+                        (input)="inputfilters.filterNumericInput($event, partnersFormGroup, ['randomPartnersMin'])"
                         [ngClass]="{ 'error': partnersFormGroup.get('randomPartnersMin').invalid || partnersFormGroup.get('randomPartnersMax').hasError('greaterOrEqual')}">
                 <span class="settings-label">Min number of starting partners</span>
             </div>
@@ -50,6 +51,7 @@
                          max="8"
                          formControlName='randomPartnersMax'
                          (blur)="onRandomPartnersMaxBlur()"
+                         (input)="inputfilters.filterNumericInput($event, partnersFormGroup, ['randomPartnersMax'])"
                          [ngClass]="{ 'error': partnersFormGroup.get('randomPartnersMax').invalid}">
                 <span class="settings-label">Max number of starting partners</span>
             </div>
@@ -96,13 +98,13 @@
             Minimum number of starting partners must be greater or equal to 1
         </li>
         <li *ngIf="partnersFormGroup.get('randomPartnersMin').hasError('max')">
-            Minimum number of starting partners must be smaller or equal to 8
+            Total of starting and plandomized partners cannot exceed 8
         </li>
         <li *ngIf="partnersFormGroup.get('randomPartnersMax').hasError('min')">
             Maximum number of starting partners must be greater or equal to 1
         </li>
         <li *ngIf="partnersFormGroup.get('randomPartnersMax').hasError('max')">
-            Maximum number of starting partners must be smaller or equal to 8
+            Total of starting and plandomized partners cannot exceed 8
         </li>
         <li *ngIf="partnersFormGroup.get('randomPartnersMax').hasError('greaterOrEqual')">
             Maximum number of starting partners must be greater or equal to minimum

--- a/app/src/app/pages/home/randomizer-page/partners/partners.component.html
+++ b/app/src/app/pages/home/randomizer-page/partners/partners.component.html
@@ -57,34 +57,34 @@
         <ng-template #fixedPartnersTemplate>
             <form [formGroup]="partnersFormGroup.get('startWithPartners')" class="full-width-element">
                 <div class="setting-element">
-                    <mat-checkbox formControlName='goombario'></mat-checkbox>
+                    <mat-checkbox formControlName='goombario' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Goombario</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='kooper'></mat-checkbox>
+                    <mat-checkbox formControlName='kooper' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Kooper</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='bombette'></mat-checkbox>
+                    <mat-checkbox formControlName='bombette' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Bombette</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='parakarry'></mat-checkbox>
+                    <mat-checkbox formControlName='parakarry' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Parakarry</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='bow'></mat-checkbox>
+                    <mat-checkbox formControlName='bow' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Bow</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='watt'></mat-checkbox>
+                    <mat-checkbox formControlName='watt' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Watt</span>
                 </div>
                 <div class="setting-element">
-                    <mat-checkbox formControlName='sushie'></mat-checkbox>
+                    <mat-checkbox formControlName='sushie' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Sushie</span>
                 </div><div class="setting-element">
-                    <mat-checkbox formControlName='lakilester'></mat-checkbox>
+                    <mat-checkbox formControlName='lakilester' plandoAssignable></mat-checkbox>
                     <span class="settings-label">Lakilester</span>
                 </div>
             </form>

--- a/app/src/app/pages/home/randomizer-page/partners/partners.component.ts
+++ b/app/src/app/pages/home/randomizer-page/partners/partners.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { tap, Subscription } from 'rxjs';
+import { InputFilterService } from "src/app/services/inputfilter.service";
 
 @Component({
   selector: 'app-partners',
@@ -13,7 +14,7 @@ export class PartnersComponent implements OnInit, OnDestroy {
 
   private _startWithRandomPartnersSubscription: Subscription
 
-  public constructor() { }
+  public constructor(public inputfilters: InputFilterService) { }
   
 
   public ngOnInit(): void {

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.html
@@ -25,9 +25,10 @@
     <div class="row" *ngIf="plandoAssignedControls.size > 0">
         <p>Based on the selected plando, the following settings have been adjusted automatically:</p>
         <ul>
-            <li *ngFor="let control of plandoAssignedControls">
-                <span>{{controlDisplayStrings.get(control)}}</span>
-            </li>
+            <ng-container *ngFor="let control of plandoAssignedControls">
+                <li *ngIf="!PARTNERS_SET.has(control)">{{controlDisplayStrings.get(control)}}</li>
+            </ng-container>
+            <li *ngIf="anyPartnerPlandoed">Start with Specific Partner(s)</li>
         </ul>
     </div>
 </mat-card-content>

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from "@angular/forms";
 import { Subscription } from "rxjs";
+import { PARTNERS } from "src/app/pages/plando-page/plando-constants";
 import { SAVED_PLANDO_NAME_PREFIX, SAVED_PLANDO_NAMES_KEY } from "src/app/pages/plando-page/plando-save-load/plando-save-load.component";
 import { PlandoAssignmentService } from "src/app/services/plando-assignment.service";
 
@@ -13,6 +14,7 @@ export class PlandomizersComponent implements OnInit, OnDestroy {
   @Input() public plandomizerFormControl: FormControl;
 
   private _plandoAssignmentSubscription: Subscription;
+  public readonly PARTNERS_SET = new Set(Array.from(PARTNERS).map((p) => p.toLowerCase()));
   public readonly controlDisplayStrings: Map<string, string> = new Map([
     ["shuffleItems", "Shuffle Items"],
     ["includePanels", "Include Hidden Panels"],
@@ -47,13 +49,17 @@ export class PlandomizersComponent implements OnInit, OnDestroy {
   public selectedPlandoName: string;
   public loadStatus: string;
   public plandoAssignedControls: Set<string>
+  public anyPartnerPlandoed: boolean = false;
 
   constructor(private _plandoAssignmentService: PlandoAssignmentService) { }
 
   public ngOnInit(): void {
     const storedNames = window.localStorage.getItem(SAVED_PLANDO_NAMES_KEY);
     this.savedPlandoNames = storedNames ? new Set(storedNames.split(',')) : new Set();
-    this._plandoAssignmentSubscription = this._plandoAssignmentService.assignedControls.asObservable().subscribe(assignedControls => this.plandoAssignedControls = assignedControls);
+    this._plandoAssignmentSubscription = this._plandoAssignmentService.assignedControls.asObservable().subscribe(assignedControls => {
+      this.plandoAssignedControls = assignedControls;
+      this.anyPartnerPlandoed = Array.from(this.plandoAssignedControls).some((control) => this.PARTNERS_SET.has(control));
+    });
   }
 
   ngOnDestroy(): void {

--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -44,6 +44,8 @@ export class PlandomizersComponent implements OnInit, OnDestroy {
     ["addUnusedBadgeDuplicates", "Add Unused Badge Duplicates"],
     ["addBetaItems", "Add Beta Items"],
     ["progressiveBadges", "Progressive Badges"],
+    ["startWithRandomPartners", "Start with Random Partners"],
+    ["randomPartnersMax", "Max number of starting partners"]
   ]);
   public savedPlandoNames: Set<String>;
   public selectedPlandoName: string;

--- a/app/src/app/services/plando-assignment.service.ts
+++ b/app/src/app/services/plando-assignment.service.ts
@@ -51,6 +51,11 @@ export class PlandoAssignmentService {
                   }
                 }
 
+                if (PARTNERS.has(plandoItem)) {
+                  randoSettingsFormGroup.get(['partners','startWithPartners',plandoItem.toLowerCase()]).setValue(false);
+                  plandoAssignedControls.add(plandoItem.toLowerCase());
+                }
+
                 if (KOOT_FAVOR_ITEMS.has(plandoItem) && KOOT_FAVOR_CHECKS[check.name] !== plandoItem) {
                   kootFavors = 2;
                 }
@@ -215,8 +220,8 @@ export class PlandoAssignmentService {
           randoSettingsFormGroup.get('goals').get('requireSpecificSpirits').setValue(false);
         }
       }
-      this.assignedControls.next(plandoAssignedControls);
     }
+    this.assignedControls.next(plandoAssignedControls);
   }
 
 }


### PR DESCRIPTION
This PR adds some extra logic for the seed generator settings enforcement added in #48.

Specifically, it will now adjust the settings for a manually-specified set of starting partners. If a partner is set as a check in the plandomizer, their corresponding starting partner checkbox will be unchecked and disabled. 
![image](https://github.com/user-attachments/assets/748955d5-7aac-485d-9993-f616d8fa2d51)

If 7 partners are set as checks in the plandomizer, "Start with random partners" is unchecked and disabled, and the only remaining partner is set as the starting partner.
![image](https://github.com/user-attachments/assets/99278385-5fbf-4dd3-8255-5083fd62a8a0)

This PR also adds some extra logic to adjust validation for the Minimum/Maximum number of starting partners. If one or more partners is plandomized, the valid maximum number of randomized starting partners is adjusted as necessary.
![image](https://github.com/user-attachments/assets/1749cbcf-89e8-4e21-8912-b5297a7d53d0)
In the selected plando above, Watt and Bow are plandomized, meaning that 7 is no longer a valid maximum number of randomized starting partners.

This necessitated an extra change on the front-end. The existing validation message for Min/Max random starting partners only mentions the un-plandomized maximum of 8. This was done to account for users manually entering numbers exceeding 8, but the maximum number of randomized starting partners will be less than 8 if any partners are plandomized. And as far as I can tell, manually modifying the `max` attribute of the FormControl's `input` isn't very straightforward.

Thus, to make this message more fitting, a numeric input filter is added to the min/max random partner inputs, disallowing any inputs resulting in a value smaller than 1 or larger than 8. This means the `max` validation error message will only be applicable when a plandomizer is selected, allowing us to rephrase it for that purpose.

And lastly, this PR also fixes a (pretty impactful!) bug where deselecting a plandomizer (i.e. changing the plando selection to the first, blank entry to un-set the plando) would not unlock the corresponding controls.