### PR TITLE
Plando: Dungeon Entrances

### DIFF
--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.html
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.html
@@ -71,7 +71,7 @@
     </div>
 </div>
 <div [formGroup]="itemsFormGroup">
-    <mat-tab-group disablePagination="true" class="sub-tab" animationDuration="0" scrollToCenter #locationTabGroup>
+    <mat-tab-group disablePagination="true" class="sub-tab" animationDuration="0" scrollToCenter #locationTabGroup (wheel)="onScroll($event)">
         <mat-tab *ngFor="let loc of LOCATIONS">
             <ng-template mat-tab-label>
                 <label class="mat-tab-label-content" [ngClass]="{ 'error': itemsFormGroup.get(loc.name).invalid }">{{toDisplayString(loc.name)}}</label>

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -7,27 +7,6 @@ import { escapeRegexChars, pascalToVerboseString } from "src/app/utilities/strin
 import { CHECK_TYPES_DISPLAY_MAPPING, CheckType, LEGAL_TRAP_ITEMS, PLANDO_ITEMS_LIST, Region, REGIONS_LIST, VANILLA_ITEMS } from "../plando-constants";
 import { manualTrapRegex } from "../plando-page.component";
 
-const possessiveRegex = /(Mario|Peach|Boo|Guy|Troopa|King|Bowser|Rowf|Merlow|Merluvlee|Tubba|Kolorado|Bow|Lily|Petunia|Rosie)s /g;
-const displayStringReplacements = {
-  "B L U": "BLU",
-  "P N K": "PNK",
-  "G R N": "GRN",
-  "R E D": "RED",
-  "P- ": "P-",
-  "D- ": "D-",
-  "( ": "(",
-  "N W": "NW",
-  "N E": "NE",
-  "S W": "SW",
-  "S E": "SE",
-  "Bros": "Bros.",
-  "Non Progression": "Non-Progression Item",
-  "Consumable": "Random Consumable",
-}
-const replacementRegEx = new RegExp(Object.keys(displayStringReplacements).map(escapeRegexChars).join('|'), "g");
-const displayStrings: Map<string, string> = new Map<string, string>();
-
-
 @Component({
   selector: 'app-plando-items',
   templateUrl: './plando-items.component.html',
@@ -209,13 +188,6 @@ export class PlandoItemsComponent implements OnInit {
     this.massFillCheckTypes = Object.values(CheckType).filter(val => val !== CheckType.NORMAL && !this.filteredTypes.includes(val));
   }
 
-  public toDisplayString = function (s: string): string {
-    if (!displayStrings.has(s)) {
-      displayStrings.set(s, pascalToVerboseString(s).replace(possessiveRegex, "$1's").replace(replacementRegEx, function (matched) {
-        return displayStringReplacements[matched];
-      }));
-    }
-    return displayStrings.get(s);
-  }
+  public toDisplayString = pascalToVerboseString;
 
 };

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.ts
@@ -176,6 +176,14 @@ export class PlandoItemsComponent implements OnInit {
     this.itemsFormGroup.get(formControlName).updateValueAndValidity();
   }
 
+  public onScroll($event: WheelEvent) {
+    if ($event.target instanceof HTMLElement
+      && ($event.target.classList.contains('mat-tab-label-content') || $event.target.classList.contains('mat-tab-label') || $event.target.classList.contains('mat-tab-labels'))) {
+      this.locationTabGroup._elementRef.nativeElement.querySelector('.mat-tab-list').scrollLeft += $event.deltaY;
+      $event.preventDefault();
+    }
+  }
+
   public toggleCheckTypeFilter($event: MatSlideToggleChange, checkType: CheckType) {
     if ($event.checked) {
       const i = this.filteredTypes.indexOf(checkType);

--- a/app/src/app/pages/plando-page/plando-page.component.ts
+++ b/app/src/app/pages/plando-page/plando-page.component.ts
@@ -43,6 +43,16 @@ export class PlandoPageComponent implements OnInit, OnDestroy {
         'chapter 6': new FormControl<string>(null),
         'chapter 7': new FormControl<string>(null),
       }),
+      dungeon_entrances: new FormGroup({
+        'PleasantPath': new FormControl<string>(null),
+        'DryDryDesert': new FormControl<string>(null),
+        'GustyGulch': new FormControl<string>(null),
+        'EnterToyBox': new FormControl<string>(null),
+        'LavalavaIsland': new FormControl<string>(null),
+        'EnterFlowerGate': new FormControl<string>(null),
+        'ShiverMountain': new FormControl<string>(null),
+        'RideStarShip': new FormControl<string>(null),
+      }),
       required_spirits: new FormControl<Array<string>>(null),
       move_costs: new FormGroup({
         badge: new FormGroup({}),

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.html
@@ -6,7 +6,7 @@
   <div class="container">
     <div *ngFor="let spirit of SPIRITS; let i = index; let requiredSpirits = requiredSpirits" class="panel">
       <h3 class="row text-center">Chapter {{ i + 1 }}</h3>
-      <div>
+      <div *ngIf="spirit !== ''">
         <label>
           <input
             type="checkbox"
@@ -24,17 +24,27 @@
         </label>
       </div>
       <div class="settings">
-        <div class="row" formGroupName="difficulty">
+        <div *ngIf="spirit !== ''" class="row" formGroupName="difficulty">
           <app-tooltip-span class="row"
             [spanText]="'Difficulty: ' + (getChapterDifficulty(i+1) > 0 ? getChapterDifficulty(i+1) : '?')"
             tooltipText="Set the difficulty scaling for this chapter. If set to '?', the seed generator settings will determine scaling."></app-tooltip-span>
           <mat-slider formControlName="{{ 'chapter ' + (i + 1) }}" (input)="setChapterDifficulty(i+1, $event.value)" min="0" max="8" step="1" tickInterval="1"></mat-slider>
         </div>
-        <div class="row" formGroupName="boss_battles">
+        <div class="row" formGroupName="dungeon_entrances">
+          <label for="{{ CHAPTER_OVERWORLDS[i] }}">Dungeon:</label>
+          <select formControlName="{{ CHAPTER_OVERWORLDS[i] }}">
+            <option value=""></option>
+            <option *ngFor="let dungeon of DUNGEONS" [value]="dungeon">
+              {{ toDisplayString(dungeon) }}
+            </option>
+          </select>
+        </div>
+        <div *ngIf="spirit !== ''" class="row" formGroupName="boss_battles">
           <label for="{{ 'chapter ' + (i + 1) }}">Boss:</label>
           <select formControlName="{{ 'chapter ' + (i + 1) }}">
-            <option *ngFor="let boss of BOSSES" [value]="boss.id">
-              {{ boss.displayName }}
+            <option value=""></option>
+            <option *ngFor="let boss of BOSSES" [value]="boss">
+              {{ toDisplayString(boss) }}
             </option>
           </select>
         </div>

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -3,11 +3,6 @@ import { FormGroup } from '@angular/forms';
 import { Subscription } from "rxjs";
 import { pascalToVerboseString } from "src/app/utilities/stringFunctions";
 
-type Boss = {
-  id: string;
-  displayName: string;
-}
-
 export const STAR_SPIRIT_POWER_NAMES: Array<string> = ['Refresh', 'Lullaby', 'StarStorm', 'ChillOut', 'Smooch', 'TimeOut', 'UpAndAway'];
 
 @Component({
@@ -19,16 +14,10 @@ export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy, Aft
   @Input() plandoFormGroup: FormGroup;
 
   public readonly SPIRIT_POWERS: Array<string> = STAR_SPIRIT_POWER_NAMES;
-  public readonly SPIRITS: Array<string> = ['Eldstar', 'Mamar', 'Skolar', 'Muskular', 'Misstar', 'Klevar', 'Kalmar'];
-  public readonly BOSSES: Array<Boss> = [
-    { id: '', displayName: '' },
-    { id: 'KoopaBros', displayName: 'Koopa Bros.' },
-    { id: 'Tutankoopa', displayName: 'Tutankoopa' },
-    { id: 'TubbasHeart', displayName: 'Tubba\'s Heart' },
-    { id: 'GeneralGuy', displayName: 'General Guy' },
-    { id: 'LavaPiranha', displayName: 'Lava Piranha' },
-    { id: 'HuffNPuff', displayName: 'Huff N Puff' },
-    { id: 'CrystalKing', displayName: 'Crystal King' }];
+  public readonly SPIRITS: Array<string> = ['Eldstar', 'Mamar', 'Skolar', 'Muskular', 'Misstar', 'Klevar', 'Kalmar', ''];
+  public readonly CHAPTER_OVERWORLDS: Array<string> = ['PleasantPath', 'DryDryDesert', 'GustyGulch', 'EnterToyBox', 'LavalavaIsland', 'EnterFlowerGate', 'ShiverMountain', 'RideStarShip'];
+  public readonly DUNGEONS: Array<string> = ['KoopaBrosFortress', 'DryDryRuins', 'TubbasCastle', 'ShyGuysToybox', 'MtLavalava', 'FlowerFields', 'CrystalPalace', 'BowsersCastle'];
+  public readonly BOSSES: Array<string> = ['KoopaBros', 'Tutankoopa', 'TubbasHeart', 'GeneralGuy', 'LavaPiranha', 'HuffNPuff', 'CrystalKing'];
   public spiritsSubscription: Subscription;
   public requiredSpiritsArray = Array<string>();
   public toDisplayString = pascalToVerboseString;

--- a/app/src/app/utilities/stringFunctions.ts
+++ b/app/src/app/utilities/stringFunctions.ts
@@ -15,7 +15,21 @@ const verboseStringReplacements = {
     "D Up": "D-Up",
     'P Down': "P-Down",
     "P Up": "P-Up",
-    "Allor": "All or"
+    "Allor": "All or",
+    "B L U": "BLU",
+    "P N K": "PNK",
+    "G R N": "GRN",
+    "R E D": "RED",
+    "P- ": "P-",
+    "D- ": "D-",
+    "( ": "(",
+    "N W": "NW",
+    "N E": "NE",
+    "S W": "SW",
+    "S E": "SE",
+    "Bros": "Bros.",
+    "Non Progression": "Non-Progression Item",
+    "Consumable": "Random Consumable",
 }
 
 export function escapeRegexChars(val: string): string {
@@ -24,6 +38,7 @@ export function escapeRegexChars(val: string): string {
 
 const verboseStrings: Map<string, string> = new Map<string, string>();
 
+const possessiveRegex = /(Mario|Peach|Boo|Guy|Troopa|King|Bowser|Rowf|Merlow|Merluvlee|Tubba|Kolorado|Bow|Lily|Petunia|Rosie)s/g;
 const stringReplaceRegEx = new RegExp(Object.keys(verboseStringReplacements).map(escapeRegexChars).join('|'), 'g');
 
 export function pascalToVerboseString(text: string): string {
@@ -34,16 +49,17 @@ export function pascalToVerboseString(text: string): string {
         if (text.includes("Letter") && text.length == 8) {
             return Constants.VERBOSE_LETTER_NAMES[text];
         }
-    
+
         if (text.includes("MagicalSeed")) {
             return text.replace(/([A-Z0-9])/g, " $1");
         }
-    
+
         var cleanText = text.replace(/([A-Z])/g, " $1");
         cleanText = cleanText.charAt(0).toUpperCase() + cleanText.slice(1);
         cleanText = cleanText.replace(stringReplaceRegEx, function (matched) {
             return verboseStringReplacements[matched];
-        }).trimStart()
+        }).trimStart().replace(possessiveRegex, "$1's");
+
         verboseStrings.set(text, cleanText);
     }
 


### PR DESCRIPTION
This PR adds a first pass at the inputs for dungeon entrance plandomizing.

![image](https://github.com/user-attachments/assets/a5c617ad-68df-45d0-a633-3b7793f98a17)

Not fully sold on this presentation, particularly with the Chapter 8 panel being so empty, but the dungeons do fit nicely in the others.

This PR also includes some cleanup, replacing the last needless ad-hoc `id`/`displayString` type with the usual logic for display strings, making things a bit more consistent. Merged my display string function into `stringFunctions`. I was hesitant to do this earlier since I didn't want to risk messing up strings on the seed generator, but I didn't see anything troublesome.

Lastly, I added functionality to horizontally scroll the tab list on the items tab automatically when the mouse is over the tab list. Just feels a bit better that way, in retrospect.