### PR TITLE
Plandomizer: Star Spirit Shuffle

### DIFF
--- a/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
+++ b/app/src/app/pages/home/randomizer-page/plandomizers/plandomizers.component.ts
@@ -21,6 +21,7 @@ export class PlandomizersComponent implements OnInit, OnDestroy {
     ["keyitemsOutsideDungeon", "Keysanity"],
     ["includeRadioTradeEvent", "Include Trading Event Rewards"],
     ["gearShuffleMode", "Gear Shuffle"],
+    ["spiritShuffleMode", "Star Spirit Shuffle"],
     ["includeLetters", "Letter Delivery Rewards"],
     ["includeFavors", "Koopa Koot Favors"],
     ["ripCheatoItemsInLogic", "Rip Cheato Items in Logic"],

--- a/app/src/app/pages/plando-page/plando-constants.ts
+++ b/app/src/app/pages/plando-page/plando-constants.ts
@@ -324,6 +324,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "Jail - Bombette Partner", type: CheckType.NORMAL, vanillaItem: "Bombette" },
             { name: "Dungeon Fire Room - On The Ground", type: CheckType.NORMAL, vanillaItem: "KoopaFortressKey" },
             { name: "Battlement - Block Behind Rock", type: CheckType.NORMAL, vanillaItem: "MapleSyrup" },
+            { name: "Boss Battle Room - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Eldstar" },
         ]
     },
     {
@@ -455,6 +456,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "Diamond Stone Room - On Pedestal", type: CheckType.NORMAL, vanillaItem: "DiamondStone" },
             { name: "Sand Drainage Room 3 - On Ledge", type: CheckType.NORMAL, vanillaItem: "RuinsKey" },
             { name: "Lunar Stone Room - On Pedestal", type: CheckType.NORMAL, vanillaItem: "LunarStone" },
+            { name: "Tutankoopa Room - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Mamar" },
         ]
     },
     {
@@ -507,6 +509,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "Wasteland Ascent 2 - In MultiCoinBlock", type: CheckType.MULTICOIN_BLOCK, vanillaItem: "CoinBag" },
             { name: "Wasteland Ascent 2 - Yellow Block Left", type: CheckType.NORMAL, vanillaItem: "SuperShroom" },
             { name: "Wasteland Ascent 2 - Yellow Block Right", type: CheckType.COIN_BLOCK, vanillaItem: "Coin" },
+            { name: "Windmill Exterior - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Skolar" },
         ]
     },
     {
@@ -607,6 +610,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "RED Boss Barricade - Hidden Block Left", type: CheckType.COIN_BLOCK, vanillaItem: "Coin" },
             { name: "RED Boss Barricade - On Brick Block", type: CheckType.NORMAL, vanillaItem: "ShootingStar" },
             { name: "RED Boss Barricade - Yellow Block Right", type: CheckType.NORMAL, vanillaItem: "SleepySheep" },
+            { name: "RED General Guy Room - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Muskular" },
         ]
     },
     {
@@ -697,6 +701,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "Boss Antechamber - Hidden Panel", type: CheckType.HIDDEN_PANEL, vanillaItem: "StarPiece" },
             { name: "Boss Room - Yellow Block Left", type: CheckType.NORMAL, vanillaItem: "SuperShroom" },
             { name: "Boss Room - Yellow Block Right", type: CheckType.NORMAL, vanillaItem: "MapleSyrup" },
+            { name: "Boss Room - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Misstar" },
         ]
     },
     {
@@ -741,6 +746,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "(NW) Lakilester - In The Flowers", type: CheckType.NORMAL, vanillaItem: "ShootingStar" },
             { name: "(NW) Lakilester - Lakilester Partner", type: CheckType.NORMAL, vanillaItem: "Lakilester" },
             { name: "Cloudy Climb - On Cloud", type: CheckType.NORMAL, vanillaItem: "SJumpCharge" },
+            { name: "Huff N Puff Room - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Klevar" },
         ]
     },
     {
@@ -797,6 +803,7 @@ export const REGIONS_LIST: Array<Region> = [
             { name: "Small Statue Room - Hidden Panel", type: CheckType.HIDDEN_PANEL, vanillaItem: "StarPiece" },
             { name: "Small Statue Room - Hidden Block", type: CheckType.NORMAL, vanillaItem: "JamminJelly" },
             { name: "P-Up, D-Down Room - In Chest", type: CheckType.NORMAL, vanillaItem: "PUpDDown" },
+            { name: "Crystal Summit - Boss Reward", type: CheckType.NORMAL, vanillaItem: "Kalmar" },
         ]
     },
     {
@@ -919,6 +926,7 @@ export const PLANDO_ITEMS_LIST: Array<PlandoItem> = [
     { code: "Egg", canMassFill: true },
     { code: "EggMissile", canMassFill: true },
     { code: "ElectroPop", canMassFill: true },
+    { code: "Eldstar", canMassFill: false },
     { code: "FPPlus", canMassFill: false },
     { code: "FeelingFine", canMassFill: false },
     { code: "FertileSoil", canMassFill: false },
@@ -969,6 +977,8 @@ export const PLANDO_ITEMS_LIST: Array<PlandoItem> = [
     { code: "JellySuper", canMassFill: true },
     { code: "JellyUltra", canMassFill: true },
     { code: "JumpCharge", canMassFill: false },
+    { code: "Kalmar", canMassFill: false },
+    { code: "Klevar", canMassFill: false },
     { code: "KookyCookie", canMassFill: true },
     { code: "KoopaFortressKey", canMassFill: false },
     { code: "KoopaLeaf", canMassFill: true },
@@ -1028,6 +1038,7 @@ export const PLANDO_ITEMS_LIST: Array<PlandoItem> = [
     { code: "MagicalSeed3", canMassFill: false },
     { code: "MagicalSeed4", canMassFill: false },
     { code: "Mailbag", canMassFill: false },
+    { code: "Mamar", canMassFill: false },
     { code: "MapleShroom", canMassFill: true },
     { code: "MapleSuper", canMassFill: true },
     { code: "MapleSyrup", canMassFill: true },
@@ -1042,10 +1053,12 @@ export const PLANDO_ITEMS_LIST: Array<PlandoItem> = [
     { code: "MiniJumpCharge", canMassFill: false },
     { code: "MiniSmashCharge", canMassFill: false },
     { code: "MiracleWater", canMassFill: false },
+    { code: "Misstar", canMassFill: false },
     { code: "Mistake", canMassFill: true },
     { code: "MoneyMoney", canMassFill: false },
     { code: "Multibounce", canMassFill: false },
     { code: "Mushroom", canMassFill: true },
+    { code: "Muskular", canMassFill: false },
     { code: "Mystery", canMassFill: true },
     { code: "MysteryNote", canMassFill: false },
     { code: "NuttyCake", canMassFill: true },
@@ -1096,6 +1109,7 @@ export const PLANDO_ITEMS_LIST: Array<PlandoItem> = [
     { code: "ShroomCake", canMassFill: true },
     { code: "ShroomSteak", canMassFill: true },
     { code: "SilverCredit", canMassFill: false },
+    { code: "Skolar", canMassFill: false },
     { code: "SleepStomp", canMassFill: false },
     { code: "SleepySheep", canMassFill: true },
     { code: "SlowGo", canMassFill: false },

--- a/app/src/app/pages/plando-page/plando-constants.ts
+++ b/app/src/app/pages/plando-page/plando-constants.ts
@@ -849,7 +849,7 @@ export const REGIONS_LIST: Array<Region> = [
         ]
     }];
 
-// A nested object of vanilla items, keyed first by region, then by check name. VANILLA_ITEMS['Goomba Region']['']
+// A nested object of vanilla items, keyed first by region, then by check name. VANILLA_ITEMS['Goomba Region'][Jr. Troopa's Playground - In Tree Right'] = 'Dolly'
 export const VANILLA_ITEMS = Object.fromEntries(REGIONS_LIST.map((region) => [region.name, Object.fromEntries(region.checks.map((check) => [check.name, check.vanillaItem]))]));
 
 type PlandoItem = {
@@ -1184,6 +1184,16 @@ export const KEY_TO_DUNGEON = {
 }
 
 export const DUNEGON_KEYS = new Set(Object.keys(KEY_TO_DUNGEON));
+
+export const SPIRIT_TO_HOME_CHAPTER_REGIONS = {
+    "Eldstar": ["Koopa Region","Koopa Bros Fortress"],
+    "Mamar": ["Mt Rugged","Dry Dry Outpost","Dry Dry Desert","Dry Dry Ruins"],
+    "Skolar": ["Forever Forest","Boos Mansion","Gusty Gulch","Tubbas Castle"],
+    "Muskular": ["Shy Guys Toybox"],
+    "Misstar": ["Jade Jungle","Mt Lavalava"],
+    "Klevar": ["Flower Fields"],
+    "Kalmar": ["Shiver Region","Crystal Palace"]
+};
 
 export const PARTNERS = new Set([
     "Goombario",

--- a/app/src/app/pages/plando-page/plando-constants.ts
+++ b/app/src/app/pages/plando-page/plando-constants.ts
@@ -1196,6 +1196,16 @@ export const PARTNERS = new Set([
     "Lakilester"
 ]);
 
+export const STAR_SPIRITS = new Set([
+    "Eldstar",
+    "Mamar",
+    "Skolar",
+    "Muskular",
+    "Misstar",
+    "Klevar",
+    "Kalmar"
+]);
+
 export const SUPER_BLOCK_LOCATIONS = new Set(REGIONS_LIST.flatMap((loc) => loc.checks.filter((check) => check.name.includes('In SuperBlock')).map((check) => check.name)));
 
 export const PROGRESSIVE_BADGES = new Set([

--- a/app/src/app/pages/plando-page/plando-items/plando-items.component.scss
+++ b/app/src/app/pages/plando-page/plando-items/plando-items.component.scss
@@ -30,12 +30,13 @@ code {
   width: 100%;
   column-count: auto;
   column-width: 550px;
+  margin-top: 10px;
 }
 .check-entry {
   display: grid;
   align-items: center;
   grid-template-columns: 5fr 4fr 4rem 4rem;
-  margin: 10px 0;
+  margin: 0 0 10px;
 }
 .panel {
     .setting-element {

--- a/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
+++ b/app/src/app/pages/plando-page/plando-spirits-and-chapters/plando-spirits-and-chapters.component.ts
@@ -2,6 +2,7 @@ import { AfterContentInit, Component, Input, OnDestroy, OnInit } from '@angular/
 import { FormGroup } from '@angular/forms';
 import { Subscription } from "rxjs";
 import { pascalToVerboseString } from "src/app/utilities/stringFunctions";
+import { STAR_SPIRITS } from "../plando-constants";
 
 export const STAR_SPIRIT_POWER_NAMES: Array<string> = ['Refresh', 'Lullaby', 'StarStorm', 'ChillOut', 'Smooch', 'TimeOut', 'UpAndAway'];
 
@@ -14,7 +15,7 @@ export class PlandoSpiritsAndChaptersComponent implements OnInit, OnDestroy, Aft
   @Input() plandoFormGroup: FormGroup;
 
   public readonly SPIRIT_POWERS: Array<string> = STAR_SPIRIT_POWER_NAMES;
-  public readonly SPIRITS: Array<string> = ['Eldstar', 'Mamar', 'Skolar', 'Muskular', 'Misstar', 'Klevar', 'Kalmar', ''];
+  public readonly SPIRITS: Array<string> = [...STAR_SPIRITS, ''];
   public readonly CHAPTER_OVERWORLDS: Array<string> = ['PleasantPath', 'DryDryDesert', 'GustyGulch', 'EnterToyBox', 'LavalavaIsland', 'EnterFlowerGate', 'ShiverMountain', 'RideStarShip'];
   public readonly DUNGEONS: Array<string> = ['KoopaBrosFortress', 'DryDryRuins', 'TubbasCastle', 'ShyGuysToybox', 'MtLavalava', 'FlowerFields', 'CrystalPalace', 'BowsersCastle'];
   public readonly BOSSES: Array<string> = ['KoopaBros', 'Tutankoopa', 'TubbasHeart', 'GeneralGuy', 'LavaPiranha', 'HuffNPuff', 'CrystalKing'];

--- a/app/src/app/services/plando-assignment.service.ts
+++ b/app/src/app/services/plando-assignment.service.ts
@@ -39,10 +39,12 @@ export class PlandoAssignmentService {
               if (plandoChecks[check.name]) {
                 const plandoItem = check.type === CheckType.SHOP ? plandoChecks[check.name].item : plandoChecks[check.name];
 
-                if (!plandoItem || VANILLA_ITEMS[region.name][check.name] === plandoItem) {
+                if (!plandoItem) {
                   continue;
                 }
-                plandoCheckTypes.add(check.type);
+                if (VANILLA_ITEMS[region.name][check.name] !== plandoItem) {
+                  plandoCheckTypes.add(check.type);
+                }
 
                 if (DUNEGON_KEYS.has(plandoItem)
                   && (KEY_TO_DUNGEON[plandoItem] !== region.name)) {
@@ -50,7 +52,8 @@ export class PlandoAssignmentService {
                   plandoAssignedControls.add('keyitemsOutsideDungeon');
                 }
 
-                if (plandoItem === 'ProgressiveHammer' || plandoItem === 'ProgressiveBoots') {
+                if (VANILLA_ITEMS[region.name][check.name] !== plandoItem
+                  && (plandoItem === 'ProgressiveHammer' || plandoItem === 'ProgressiveBoots')) {
                   if (!GEAR_LOCATIONS.has(check.name)) {
                     gearShuffle = 2;
                   } else {
@@ -68,12 +71,12 @@ export class PlandoAssignmentService {
                   partnersPlandoed++;
                   if (!check.name.endsWith(' Partner')) {
                     partnerShuffle = 2;
-                  } else {
+                  } else if (VANILLA_ITEMS[region.name][check.name] !== plandoItem) {
                     partnerShuffle = Math.max(partnerShuffle, 1);
                   }
                 }
 
-                if (STAR_SPIRITS.has(plandoItem)) {
+                if (STAR_SPIRITS.has(plandoItem) && VANILLA_ITEMS[region.name][check.name] !== plandoItem) {
                   if (!SPIRIT_TO_HOME_CHAPTER_REGIONS[plandoItem].includes(region.name)) {
                     spiritShuffle = 2;
                   } else {
@@ -90,7 +93,7 @@ export class PlandoAssignmentService {
                   plandoCheckTypes.add(CheckType.SHOP);
                 }
 
-                if (check.type === CheckType.LETTER_REWARD) {
+                if (check.type === CheckType.LETTER_REWARD && VANILLA_ITEMS[region.name][check.name] !== plandoItem) {
                   if (LETTER_CHAIN_CHECKS.has(check.name)) {
                     letterShuffle = 3;
                   } else if (check.name === 'Goomba Village - Goompapa Letter Reward 2') {
@@ -117,7 +120,7 @@ export class PlandoAssignmentService {
                   plandoAssignedControls.add('itemPouches');
                 }
 
-                if (plandoItem.includes('Upgrade')) {
+                if (plandoItem.includes('Upgrade') && VANILLA_ITEMS[region.name][check.name] !== plandoItem) {
                   if (!SUPER_BLOCK_LOCATIONS.has(check.name)) {
                     partnerUpgradeShuffle = 2;
                   } else {

--- a/app/src/app/services/plando-assignment.service.ts
+++ b/app/src/app/services/plando-assignment.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { FormGroup, Validators } from "@angular/forms";
 import { BehaviorSubject } from "rxjs";
-import { CheckType, DOJO_CHECK_VALUES, DUNEGON_KEYS, GEAR_LOCATIONS, KEY_TO_DUNGEON, KOOT_FAVOR_CHECKS, KOOT_FAVOR_ITEMS, LETTER_CHAIN_CHECKS, PARTNERS, PROGRESSIVE_BADGES, REGIONS_LIST, ROWF_MERLOW_BADGES, SUPER_BLOCK_LOCATIONS } from "../pages/plando-page/plando-constants";
+import { CheckType, DOJO_CHECK_VALUES, DUNEGON_KEYS, GEAR_LOCATIONS, KEY_TO_DUNGEON, KOOT_FAVOR_CHECKS, KOOT_FAVOR_ITEMS, LETTER_CHAIN_CHECKS, PARTNERS, PROGRESSIVE_BADGES, REGIONS_LIST, ROWF_MERLOW_BADGES, SPIRIT_TO_HOME_CHAPTER_REGIONS, STAR_SPIRITS, SUPER_BLOCK_LOCATIONS, VANILLA_ITEMS } from "../pages/plando-page/plando-constants";
 import { CustomValidators } from "../utilities/custom.validators";
 
 @Injectable({
@@ -21,6 +21,7 @@ export class PlandoAssignmentService {
       let powerStars: number = 0;
       let traps: number = 0;
       let gearShuffle: number = 0;
+      let spiritShuffle: number = 0;
       let partnerShuffle: number = 0;
       let partnerUpgradeShuffle: number = 0;
       let letterShuffle: number = 0;
@@ -38,7 +39,7 @@ export class PlandoAssignmentService {
               if (plandoChecks[check.name]) {
                 const plandoItem = check.type === CheckType.SHOP ? plandoChecks[check.name].item : plandoChecks[check.name];
 
-                if (!plandoItem) {
+                if (!plandoItem || VANILLA_ITEMS[region.name][check.name] === plandoItem) {
                   continue;
                 }
                 plandoCheckTypes.add(check.type);
@@ -69,6 +70,14 @@ export class PlandoAssignmentService {
                     partnerShuffle = 2;
                   } else {
                     partnerShuffle = Math.max(partnerShuffle, 1);
+                  }
+                }
+
+                if (STAR_SPIRITS.has(plandoItem)) {
+                  if (!SPIRIT_TO_HOME_CHAPTER_REGIONS[plandoItem].includes(region.name)) {
+                    spiritShuffle = 2;
+                  } else {
+                    spiritShuffle = Math.max(spiritShuffle, 1);
                   }
                 }
 
@@ -194,6 +203,10 @@ export class PlandoAssignmentService {
         if (gearShuffle) {
           randoSettingsFormGroup.get('items').get('gearShuffleMode').setValue(gearShuffle);
           plandoAssignedControls.add('gearShuffleMode');
+        }
+        if (spiritShuffle) {
+          randoSettingsFormGroup.get('items').get('spiritShuffleMode').setValue(spiritShuffle);
+          plandoAssignedControls.add('spiritShuffleMode');
         }
         if (partnerShuffle) {
           randoSettingsFormGroup.get('partners').get('shufflePartners').setValue(partnerShuffle);


### PR DESCRIPTION
This PR updates the Plandomizer page for the new Star Spirits Shuffle feature.

- Plando Constants file has been updated to add the new checks and items. Because the UI is built off of these constants, the UI updates come for free.
<img width="748" height="416" alt="image" src="https://github.com/user-attachments/assets/037ffbc0-4229-4e0e-8a0d-931f0740c329" />

- Logic has been added to auto-adjust the "Star Spirit Shuffle" setting when a plando is selected that has placed one or more Star Spirits. If all plando'd Spirits are within their vanilla chapters, it will be set to "Shuffle Within Chapter". Otherwise, "Full Shuffle" will be selected.
  - As with other `select`-type settings, the Plandomizer assignment does not lock this field for editing, to allow a user to place some spirits within their home chapters but fully randomize the rest (for example).
- Logic for plandomizer settings assignment has been refined slightly. For example: previously, plando'ing any `ProgressiveBoots` item would, at minimum, set Gear Shuffle to Gear Location Shuffle, even if all `ProgressiveBoots` assignments were vanilla. The Plando Assignment Service has been made a bit more logical by ignoring vanilla assignments if they wouldn't create more restrictive settings. I *think* this behaviour makes logical sense, but feel free to correct me if I'm off-base.
- The padding at the top of the items list has been made consistent per-column:

<img width="948" height="69" alt="image" src="https://github.com/user-attachments/assets/2809515d-c09a-4164-a01a-9c84543aa1ce" />
<img width="973" height="56" alt="image" src="https://github.com/user-attachments/assets/caaff1bb-d814-459f-88b9-7dca728e26ca" />

